### PR TITLE
feat(ts): adds several deprecated modules (#184)

### DIFF
--- a/ts/.eslintrc.json
+++ b/ts/.eslintrc.json
@@ -2,9 +2,13 @@
   "ignorePatterns": ["node_modules/", "build/", "umd/"],
   "env": {
     "node": true,
-    "es2021": true
+    "es2021": true,
+    "jest": true
   },
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": "latest",
@@ -18,23 +22,7 @@
         "ignoreRestSiblings": true
       }
     ],
-    "simple-import-sort/imports": [
-      "error",
-      {
-        "groups": [
-          ["^(@|src|@src)?\\w"],
-          [
-            "^(src|main|core|arc-storybook|viz|design-system|placement|reporting|onboarding)(/.*|$)",
-            "^\\u0000",
-            "^\\.\\.(?!/?$)",
-            "^\\.\\./?$",
-            "^\\./(?=.*/)(?!/?$)",
-            "^\\.(?!/?$)",
-            "^\\./?$"
-          ]
-        ]
-      }
-    ]
+    "simple-import-sort/imports": "error"
   },
   "overrides": [
     {

--- a/ts/jest.config.js
+++ b/ts/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   collectCoverageFrom: [
     '<rootDir>/src/**/*.{js,ts}',
     '!<rootDir>/src/generated/**/*',
+    '!<rootDir>/src/deprecated/**/*',
     '!<rootDir>/src/patch/index.*',
   ],
   projects: [

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -19,6 +19,7 @@
         "@typescript-eslint/eslint-plugin": "^7.2.0",
         "conventional-changelog-conventionalcommits": "^7.0.2",
         "eslint": "^8.57.0",
+        "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-simple-import-sort": "^12.0.0",
         "jest": "^29.7.0",
         "lint-staged": "^15.2.2",
@@ -1592,6 +1593,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3920,6 +3933,50 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
+      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-simple-import-sort": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.0.0.tgz",
@@ -4109,6 +4166,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -10539,6 +10602,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -11895,6 +11970,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/temp-dir": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -12,6 +12,7 @@
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "conventional-changelog-conventionalcommits": "^7.0.2",
     "eslint": "^8.57.0",
+    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "jest": "^29.7.0",
     "lint-staged": "^15.2.2",

--- a/ts/script/generate-exports.js
+++ b/ts/script/generate-exports.js
@@ -2,42 +2,26 @@
 
 const fs = require('fs');
 const path = require('path');
+const staticExports = require('../static-exports.json');
 
 const distDir = path.resolve(__dirname, '../dist/generated');
 const files = fs.readdirSync(distDir);
-const TYPE_REGISTRY_PATH = './dist/generated/typeRegistry';
-const paths = files.reduce(
-  (acc, file) => {
-    const match = file.match(/index.(.*)\.d\.ts/);
+const paths = files.reduce((acc, file) => {
+  const match = file.match(/index.(.*)\.d\.ts/);
 
-    if (match) {
-      const dottedPath = match[1];
-      const slashedPath = dottedPath.replace(/\./g, '/');
-      const resolvedPath = fs.existsSync(`./dist/patch/index.${dottedPath}.js`)
-        ? `./dist/patch/index.${dottedPath}`
-        : `./dist/generated/index.${dottedPath}`;
+  if (match) {
+    const dottedPath = match[1];
+    const slashedPath = dottedPath.replace(/\./g, '/');
+    const resolvedPath = fs.existsSync(`./dist/patch/index.${dottedPath}.js`)
+      ? `./dist/patch/index.${dottedPath}`
+      : `./dist/generated/index.${dottedPath}`;
 
-      acc.tsconfig[`@akashnetwork/akash-api/${slashedPath}`] = [resolvedPath];
-      acc.package[`./${slashedPath}`] = `${resolvedPath}.js`;
-    }
+    acc.tsconfig[`@akashnetwork/akash-api/${slashedPath}`] = [resolvedPath];
+    acc.package[`./${slashedPath}`] = `${resolvedPath}.js`;
+  }
 
-    return acc;
-  },
-  {
-    package: {
-      './': './dist/index.js',
-      './typeRegistry': `${TYPE_REGISTRY_PATH}.js`,
-      './akash/deployment/v1beta3/query':
-        './dist/generated/akash/deployment/v1beta3/query.js',
-    },
-    tsconfig: {
-      '@akashnetwork/akash-api/typeRegistry': [TYPE_REGISTRY_PATH],
-      '@akashnetwork/akash-api/akash/deployment/v1beta3/query': [
-        './dist/generated/akash/deployment/v1beta3/query',
-      ],
-    },
-  },
-);
+  return acc;
+}, staticExports);
 
 const tsconfigPaths = path.resolve(__dirname, '../tsconfig.paths.json');
 fs.writeFileSync(

--- a/ts/src/deprecated/akash/base/v1beta1/attribute.ts
+++ b/ts/src/deprecated/akash/base/v1beta1/attribute.ts
@@ -1,0 +1,312 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.base.v1beta1';
+
+/** Attribute represents key value pair */
+export interface Attribute {
+  $type: 'akash.base.v1beta1.Attribute';
+  key: string;
+  value: string;
+}
+
+/**
+ * SignedBy represents validation accounts that tenant expects signatures for provider attributes
+ * AllOf has precedence i.e. if there is at least one entry AnyOf is ignored regardless to how many
+ * entries there
+ * this behaviour to be discussed
+ */
+export interface SignedBy {
+  $type: 'akash.base.v1beta1.SignedBy';
+  /** all_of all keys in this list must have signed attributes */
+  allOf: string[];
+  /** any_of at least of of the keys from the list must have signed attributes */
+  anyOf: string[];
+}
+
+/** PlacementRequirements */
+export interface PlacementRequirements {
+  $type: 'akash.base.v1beta1.PlacementRequirements';
+  /** SignedBy list of keys that tenants expect to have signatures from */
+  signedBy: SignedBy | undefined;
+  /** Attribute list of attributes tenant expects from the provider */
+  attributes: Attribute[];
+}
+
+function createBaseAttribute(): Attribute {
+  return { $type: 'akash.base.v1beta1.Attribute', key: '', value: '' };
+}
+
+export const Attribute = {
+  $type: 'akash.base.v1beta1.Attribute' as const,
+
+  encode(
+    message: Attribute,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.key !== '') {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== '') {
+      writer.uint32(18).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Attribute {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseAttribute();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.string();
+          break;
+        case 2:
+          message.value = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Attribute {
+    return {
+      $type: Attribute.$type,
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object.value) ? String(object.value) : '',
+    };
+  },
+
+  toJSON(message: Attribute): unknown {
+    const obj: any = {};
+    message.key !== undefined && (obj.key = message.key);
+    message.value !== undefined && (obj.value = message.value);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Attribute>, I>>(
+    object: I,
+  ): Attribute {
+    const message = createBaseAttribute();
+    message.key = object.key ?? '';
+    message.value = object.value ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Attribute.$type, Attribute);
+
+function createBaseSignedBy(): SignedBy {
+  return { $type: 'akash.base.v1beta1.SignedBy', allOf: [], anyOf: [] };
+}
+
+export const SignedBy = {
+  $type: 'akash.base.v1beta1.SignedBy' as const,
+
+  encode(
+    message: SignedBy,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.allOf) {
+      writer.uint32(10).string(v!);
+    }
+    for (const v of message.anyOf) {
+      writer.uint32(18).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SignedBy {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSignedBy();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.allOf.push(reader.string());
+          break;
+        case 2:
+          message.anyOf.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SignedBy {
+    return {
+      $type: SignedBy.$type,
+      allOf: Array.isArray(object?.allOf)
+        ? object.allOf.map((e: any) => String(e))
+        : [],
+      anyOf: Array.isArray(object?.anyOf)
+        ? object.anyOf.map((e: any) => String(e))
+        : [],
+    };
+  },
+
+  toJSON(message: SignedBy): unknown {
+    const obj: any = {};
+    if (message.allOf) {
+      obj.allOf = message.allOf.map((e) => e);
+    } else {
+      obj.allOf = [];
+    }
+    if (message.anyOf) {
+      obj.anyOf = message.anyOf.map((e) => e);
+    } else {
+      obj.anyOf = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SignedBy>, I>>(object: I): SignedBy {
+    const message = createBaseSignedBy();
+    message.allOf = object.allOf?.map((e) => e) || [];
+    message.anyOf = object.anyOf?.map((e) => e) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(SignedBy.$type, SignedBy);
+
+function createBasePlacementRequirements(): PlacementRequirements {
+  return {
+    $type: 'akash.base.v1beta1.PlacementRequirements',
+    signedBy: undefined,
+    attributes: [],
+  };
+}
+
+export const PlacementRequirements = {
+  $type: 'akash.base.v1beta1.PlacementRequirements' as const,
+
+  encode(
+    message: PlacementRequirements,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.signedBy !== undefined) {
+      SignedBy.encode(message.signedBy, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.attributes) {
+      Attribute.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): PlacementRequirements {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePlacementRequirements();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.signedBy = SignedBy.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.attributes.push(Attribute.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PlacementRequirements {
+    return {
+      $type: PlacementRequirements.$type,
+      signedBy: isSet(object.signedBy)
+        ? SignedBy.fromJSON(object.signedBy)
+        : undefined,
+      attributes: Array.isArray(object?.attributes)
+        ? object.attributes.map((e: any) => Attribute.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: PlacementRequirements): unknown {
+    const obj: any = {};
+    message.signedBy !== undefined &&
+      (obj.signedBy = message.signedBy
+        ? SignedBy.toJSON(message.signedBy)
+        : undefined);
+    if (message.attributes) {
+      obj.attributes = message.attributes.map((e) =>
+        e ? Attribute.toJSON(e) : undefined,
+      );
+    } else {
+      obj.attributes = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PlacementRequirements>, I>>(
+    object: I,
+  ): PlacementRequirements {
+    const message = createBasePlacementRequirements();
+    message.signedBy =
+      object.signedBy !== undefined && object.signedBy !== null
+        ? SignedBy.fromPartial(object.signedBy)
+        : undefined;
+    message.attributes =
+      object.attributes?.map((e) => Attribute.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(PlacementRequirements.$type, PlacementRequirements);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/base/v1beta1/endpoint.ts
+++ b/ts/src/deprecated/akash/base/v1beta1/endpoint.ts
@@ -1,0 +1,144 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.base.v1beta1';
+
+/** Endpoint describes a publicly accessible IP service */
+export interface Endpoint {
+  $type: 'akash.base.v1beta1.Endpoint';
+  kind: Endpoint_Kind;
+}
+
+/** This describes how the endpoint is implemented when the lease is deployed */
+export enum Endpoint_Kind {
+  /** SHARED_HTTP - Describes an endpoint that becomes a Kubernetes Ingress */
+  SHARED_HTTP = 0,
+  /** RANDOM_PORT - Describes an endpoint that becomes a Kubernetes NodePort */
+  RANDOM_PORT = 1,
+  UNRECOGNIZED = -1,
+}
+
+export function endpoint_KindFromJSON(object: any): Endpoint_Kind {
+  switch (object) {
+    case 0:
+    case 'SHARED_HTTP':
+      return Endpoint_Kind.SHARED_HTTP;
+    case 1:
+    case 'RANDOM_PORT':
+      return Endpoint_Kind.RANDOM_PORT;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Endpoint_Kind.UNRECOGNIZED;
+  }
+}
+
+export function endpoint_KindToJSON(object: Endpoint_Kind): string {
+  switch (object) {
+    case Endpoint_Kind.SHARED_HTTP:
+      return 'SHARED_HTTP';
+    case Endpoint_Kind.RANDOM_PORT:
+      return 'RANDOM_PORT';
+    case Endpoint_Kind.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+function createBaseEndpoint(): Endpoint {
+  return { $type: 'akash.base.v1beta1.Endpoint', kind: 0 };
+}
+
+export const Endpoint = {
+  $type: 'akash.base.v1beta1.Endpoint' as const,
+
+  encode(
+    message: Endpoint,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.kind !== 0) {
+      writer.uint32(8).int32(message.kind);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Endpoint {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEndpoint();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.kind = reader.int32() as any;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Endpoint {
+    return {
+      $type: Endpoint.$type,
+      kind: isSet(object.kind) ? endpoint_KindFromJSON(object.kind) : 0,
+    };
+  },
+
+  toJSON(message: Endpoint): unknown {
+    const obj: any = {};
+    message.kind !== undefined &&
+      (obj.kind = endpoint_KindToJSON(message.kind));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Endpoint>, I>>(object: I): Endpoint {
+    const message = createBaseEndpoint();
+    message.kind = object.kind ?? 0;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Endpoint.$type, Endpoint);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/base/v1beta1/resource.ts
+++ b/ts/src/deprecated/akash/base/v1beta1/resource.ts
@@ -1,0 +1,451 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import { ResourceValue } from './resourcevalue';
+import { Attribute } from './attribute';
+import { Endpoint } from './endpoint';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.base.v1beta1';
+
+/** CPU stores resource units and cpu config attributes */
+export interface CPU {
+  $type: 'akash.base.v1beta1.CPU';
+  units: ResourceValue | undefined;
+  attributes: Attribute[];
+}
+
+/** Memory stores resource quantity and memory attributes */
+export interface Memory {
+  $type: 'akash.base.v1beta1.Memory';
+  quantity: ResourceValue | undefined;
+  attributes: Attribute[];
+}
+
+/** Storage stores resource quantity and storage attributes */
+export interface Storage {
+  $type: 'akash.base.v1beta1.Storage';
+  quantity: ResourceValue | undefined;
+  attributes: Attribute[];
+}
+
+/**
+ * ResourceUnits describes all available resources types for deployment/node etc
+ * if field is nil resource is not present in the given data-structure
+ */
+export interface ResourceUnits {
+  $type: 'akash.base.v1beta1.ResourceUnits';
+  cpu: CPU | undefined;
+  memory: Memory | undefined;
+  storage: Storage | undefined;
+  endpoints: Endpoint[];
+}
+
+function createBaseCPU(): CPU {
+  return { $type: 'akash.base.v1beta1.CPU', units: undefined, attributes: [] };
+}
+
+export const CPU = {
+  $type: 'akash.base.v1beta1.CPU' as const,
+
+  encode(message: CPU, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.units !== undefined) {
+      ResourceValue.encode(message.units, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.attributes) {
+      Attribute.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): CPU {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCPU();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.units = ResourceValue.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.attributes.push(Attribute.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CPU {
+    return {
+      $type: CPU.$type,
+      units: isSet(object.units)
+        ? ResourceValue.fromJSON(object.units)
+        : undefined,
+      attributes: Array.isArray(object?.attributes)
+        ? object.attributes.map((e: any) => Attribute.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: CPU): unknown {
+    const obj: any = {};
+    message.units !== undefined &&
+      (obj.units = message.units
+        ? ResourceValue.toJSON(message.units)
+        : undefined);
+    if (message.attributes) {
+      obj.attributes = message.attributes.map((e) =>
+        e ? Attribute.toJSON(e) : undefined,
+      );
+    } else {
+      obj.attributes = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CPU>, I>>(object: I): CPU {
+    const message = createBaseCPU();
+    message.units =
+      object.units !== undefined && object.units !== null
+        ? ResourceValue.fromPartial(object.units)
+        : undefined;
+    message.attributes =
+      object.attributes?.map((e) => Attribute.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(CPU.$type, CPU);
+
+function createBaseMemory(): Memory {
+  return {
+    $type: 'akash.base.v1beta1.Memory',
+    quantity: undefined,
+    attributes: [],
+  };
+}
+
+export const Memory = {
+  $type: 'akash.base.v1beta1.Memory' as const,
+
+  encode(
+    message: Memory,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.quantity !== undefined) {
+      ResourceValue.encode(message.quantity, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.attributes) {
+      Attribute.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Memory {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMemory();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.quantity = ResourceValue.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.attributes.push(Attribute.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Memory {
+    return {
+      $type: Memory.$type,
+      quantity: isSet(object.quantity)
+        ? ResourceValue.fromJSON(object.quantity)
+        : undefined,
+      attributes: Array.isArray(object?.attributes)
+        ? object.attributes.map((e: any) => Attribute.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: Memory): unknown {
+    const obj: any = {};
+    message.quantity !== undefined &&
+      (obj.quantity = message.quantity
+        ? ResourceValue.toJSON(message.quantity)
+        : undefined);
+    if (message.attributes) {
+      obj.attributes = message.attributes.map((e) =>
+        e ? Attribute.toJSON(e) : undefined,
+      );
+    } else {
+      obj.attributes = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Memory>, I>>(object: I): Memory {
+    const message = createBaseMemory();
+    message.quantity =
+      object.quantity !== undefined && object.quantity !== null
+        ? ResourceValue.fromPartial(object.quantity)
+        : undefined;
+    message.attributes =
+      object.attributes?.map((e) => Attribute.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Memory.$type, Memory);
+
+function createBaseStorage(): Storage {
+  return {
+    $type: 'akash.base.v1beta1.Storage',
+    quantity: undefined,
+    attributes: [],
+  };
+}
+
+export const Storage = {
+  $type: 'akash.base.v1beta1.Storage' as const,
+
+  encode(
+    message: Storage,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.quantity !== undefined) {
+      ResourceValue.encode(message.quantity, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.attributes) {
+      Attribute.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Storage {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStorage();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.quantity = ResourceValue.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.attributes.push(Attribute.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Storage {
+    return {
+      $type: Storage.$type,
+      quantity: isSet(object.quantity)
+        ? ResourceValue.fromJSON(object.quantity)
+        : undefined,
+      attributes: Array.isArray(object?.attributes)
+        ? object.attributes.map((e: any) => Attribute.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: Storage): unknown {
+    const obj: any = {};
+    message.quantity !== undefined &&
+      (obj.quantity = message.quantity
+        ? ResourceValue.toJSON(message.quantity)
+        : undefined);
+    if (message.attributes) {
+      obj.attributes = message.attributes.map((e) =>
+        e ? Attribute.toJSON(e) : undefined,
+      );
+    } else {
+      obj.attributes = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Storage>, I>>(object: I): Storage {
+    const message = createBaseStorage();
+    message.quantity =
+      object.quantity !== undefined && object.quantity !== null
+        ? ResourceValue.fromPartial(object.quantity)
+        : undefined;
+    message.attributes =
+      object.attributes?.map((e) => Attribute.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Storage.$type, Storage);
+
+function createBaseResourceUnits(): ResourceUnits {
+  return {
+    $type: 'akash.base.v1beta1.ResourceUnits',
+    cpu: undefined,
+    memory: undefined,
+    storage: undefined,
+    endpoints: [],
+  };
+}
+
+export const ResourceUnits = {
+  $type: 'akash.base.v1beta1.ResourceUnits' as const,
+
+  encode(
+    message: ResourceUnits,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.cpu !== undefined) {
+      CPU.encode(message.cpu, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.memory !== undefined) {
+      Memory.encode(message.memory, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.storage !== undefined) {
+      Storage.encode(message.storage, writer.uint32(26).fork()).ldelim();
+    }
+    for (const v of message.endpoints) {
+      Endpoint.encode(v!, writer.uint32(34).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ResourceUnits {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResourceUnits();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.cpu = CPU.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.memory = Memory.decode(reader, reader.uint32());
+          break;
+        case 3:
+          message.storage = Storage.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.endpoints.push(Endpoint.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ResourceUnits {
+    return {
+      $type: ResourceUnits.$type,
+      cpu: isSet(object.cpu) ? CPU.fromJSON(object.cpu) : undefined,
+      memory: isSet(object.memory) ? Memory.fromJSON(object.memory) : undefined,
+      storage: isSet(object.storage)
+        ? Storage.fromJSON(object.storage)
+        : undefined,
+      endpoints: Array.isArray(object?.endpoints)
+        ? object.endpoints.map((e: any) => Endpoint.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: ResourceUnits): unknown {
+    const obj: any = {};
+    message.cpu !== undefined &&
+      (obj.cpu = message.cpu ? CPU.toJSON(message.cpu) : undefined);
+    message.memory !== undefined &&
+      (obj.memory = message.memory ? Memory.toJSON(message.memory) : undefined);
+    message.storage !== undefined &&
+      (obj.storage = message.storage
+        ? Storage.toJSON(message.storage)
+        : undefined);
+    if (message.endpoints) {
+      obj.endpoints = message.endpoints.map((e) =>
+        e ? Endpoint.toJSON(e) : undefined,
+      );
+    } else {
+      obj.endpoints = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ResourceUnits>, I>>(
+    object: I,
+  ): ResourceUnits {
+    const message = createBaseResourceUnits();
+    message.cpu =
+      object.cpu !== undefined && object.cpu !== null
+        ? CPU.fromPartial(object.cpu)
+        : undefined;
+    message.memory =
+      object.memory !== undefined && object.memory !== null
+        ? Memory.fromPartial(object.memory)
+        : undefined;
+    message.storage =
+      object.storage !== undefined && object.storage !== null
+        ? Storage.fromPartial(object.storage)
+        : undefined;
+    message.endpoints =
+      object.endpoints?.map((e) => Endpoint.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(ResourceUnits.$type, ResourceUnits);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/base/v1beta1/resourcevalue.ts
+++ b/ts/src/deprecated/akash/base/v1beta1/resourcevalue.ts
@@ -1,0 +1,146 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.base.v1beta1';
+
+/** Unit stores cpu, memory and storage metrics */
+export interface ResourceValue {
+  $type: 'akash.base.v1beta1.ResourceValue';
+  val: Uint8Array;
+}
+
+function createBaseResourceValue(): ResourceValue {
+  return { $type: 'akash.base.v1beta1.ResourceValue', val: new Uint8Array() };
+}
+
+export const ResourceValue = {
+  $type: 'akash.base.v1beta1.ResourceValue' as const,
+
+  encode(
+    message: ResourceValue,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.val.length !== 0) {
+      writer.uint32(10).bytes(message.val);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ResourceValue {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResourceValue();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.val = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ResourceValue {
+    return {
+      $type: ResourceValue.$type,
+      val: isSet(object.val) ? bytesFromBase64(object.val) : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: ResourceValue): unknown {
+    const obj: any = {};
+    message.val !== undefined &&
+      (obj.val = base64FromBytes(
+        message.val !== undefined ? message.val : new Uint8Array(),
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ResourceValue>, I>>(
+    object: I,
+  ): ResourceValue {
+    const message = createBaseResourceValue();
+    message.val = object.val ?? new Uint8Array();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(ResourceValue.$type, ResourceValue);
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  arr.forEach((byte) => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return btoa(bin.join(''));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/cert/v1beta1/cert.ts
+++ b/ts/src/deprecated/akash/cert/v1beta1/cert.ts
@@ -1,0 +1,739 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.cert.v1beta1';
+
+/** CertificateID stores owner and sequence number */
+export interface CertificateID {
+  $type: 'akash.cert.v1beta1.CertificateID';
+  owner: string;
+  serial: string;
+}
+
+/** Certificate stores state, certificate and it's public key */
+export interface Certificate {
+  $type: 'akash.cert.v1beta1.Certificate';
+  state: Certificate_State;
+  cert: Uint8Array;
+  pubkey: Uint8Array;
+}
+
+/** State is an enum which refers to state of deployment */
+export enum Certificate_State {
+  /** invalid - Prefix should start with 0 in enum. So declaring dummy state */
+  invalid = 0,
+  /** valid - CertificateValid denotes state for deployment active */
+  valid = 1,
+  /** revoked - CertificateRevoked denotes state for deployment closed */
+  revoked = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function certificate_StateFromJSON(object: any): Certificate_State {
+  switch (object) {
+    case 0:
+    case 'invalid':
+      return Certificate_State.invalid;
+    case 1:
+    case 'valid':
+      return Certificate_State.valid;
+    case 2:
+    case 'revoked':
+      return Certificate_State.revoked;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Certificate_State.UNRECOGNIZED;
+  }
+}
+
+export function certificate_StateToJSON(object: Certificate_State): string {
+  switch (object) {
+    case Certificate_State.invalid:
+      return 'invalid';
+    case Certificate_State.valid:
+      return 'valid';
+    case Certificate_State.revoked:
+      return 'revoked';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+/** CertificateFilter defines filters used to filter certificates */
+export interface CertificateFilter {
+  $type: 'akash.cert.v1beta1.CertificateFilter';
+  owner: string;
+  serial: string;
+  state: string;
+}
+
+/** MsgCreateCertificate defines an SDK message for creating certificate */
+export interface MsgCreateCertificate {
+  $type: 'akash.cert.v1beta1.MsgCreateCertificate';
+  owner: string;
+  cert: Uint8Array;
+  pubkey: Uint8Array;
+}
+
+/** MsgCreateCertificateResponse defines the Msg/CreateCertificate response type. */
+export interface MsgCreateCertificateResponse {
+  $type: 'akash.cert.v1beta1.MsgCreateCertificateResponse';
+}
+
+/** MsgRevokeCertificate defines an SDK message for revoking certificate */
+export interface MsgRevokeCertificate {
+  $type: 'akash.cert.v1beta1.MsgRevokeCertificate';
+  id?: CertificateID;
+}
+
+/** MsgRevokeCertificateResponse defines the Msg/RevokeCertificate response type. */
+export interface MsgRevokeCertificateResponse {
+  $type: 'akash.cert.v1beta1.MsgRevokeCertificateResponse';
+}
+
+function createBaseCertificateID(): CertificateID {
+  return { $type: 'akash.cert.v1beta1.CertificateID', owner: '', serial: '' };
+}
+
+export const CertificateID = {
+  $type: 'akash.cert.v1beta1.CertificateID' as const,
+
+  encode(
+    message: CertificateID,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.serial !== '') {
+      writer.uint32(18).string(message.serial);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): CertificateID {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCertificateID();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.serial = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CertificateID {
+    return {
+      $type: CertificateID.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      serial: isSet(object.serial) ? String(object.serial) : '',
+    };
+  },
+
+  toJSON(message: CertificateID): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.serial !== undefined && (obj.serial = message.serial);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CertificateID>, I>>(
+    object: I,
+  ): CertificateID {
+    const message = createBaseCertificateID();
+    message.owner = object.owner ?? '';
+    message.serial = object.serial ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(CertificateID.$type, CertificateID);
+
+function createBaseCertificate(): Certificate {
+  return {
+    $type: 'akash.cert.v1beta1.Certificate',
+    state: 0,
+    cert: new Uint8Array(),
+    pubkey: new Uint8Array(),
+  };
+}
+
+export const Certificate = {
+  $type: 'akash.cert.v1beta1.Certificate' as const,
+
+  encode(
+    message: Certificate,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.state !== 0) {
+      writer.uint32(16).int32(message.state);
+    }
+    if (message.cert.length !== 0) {
+      writer.uint32(26).bytes(message.cert);
+    }
+    if (message.pubkey.length !== 0) {
+      writer.uint32(34).bytes(message.pubkey);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Certificate {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCertificate();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 2:
+          message.state = reader.int32() as any;
+          break;
+        case 3:
+          message.cert = reader.bytes();
+          break;
+        case 4:
+          message.pubkey = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Certificate {
+    return {
+      $type: Certificate.$type,
+      state: isSet(object.state) ? certificate_StateFromJSON(object.state) : 0,
+      cert: isSet(object.cert)
+        ? bytesFromBase64(object.cert)
+        : new Uint8Array(),
+      pubkey: isSet(object.pubkey)
+        ? bytesFromBase64(object.pubkey)
+        : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: Certificate): unknown {
+    const obj: any = {};
+    message.state !== undefined &&
+      (obj.state = certificate_StateToJSON(message.state));
+    message.cert !== undefined &&
+      (obj.cert = base64FromBytes(
+        message.cert !== undefined ? message.cert : new Uint8Array(),
+      ));
+    message.pubkey !== undefined &&
+      (obj.pubkey = base64FromBytes(
+        message.pubkey !== undefined ? message.pubkey : new Uint8Array(),
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Certificate>, I>>(
+    object: I,
+  ): Certificate {
+    const message = createBaseCertificate();
+    message.state = object.state ?? 0;
+    message.cert = object.cert ?? new Uint8Array();
+    message.pubkey = object.pubkey ?? new Uint8Array();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Certificate.$type, Certificate);
+
+function createBaseCertificateFilter(): CertificateFilter {
+  return {
+    $type: 'akash.cert.v1beta1.CertificateFilter',
+    owner: '',
+    serial: '',
+    state: '',
+  };
+}
+
+export const CertificateFilter = {
+  $type: 'akash.cert.v1beta1.CertificateFilter' as const,
+
+  encode(
+    message: CertificateFilter,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.serial !== '') {
+      writer.uint32(18).string(message.serial);
+    }
+    if (message.state !== '') {
+      writer.uint32(26).string(message.state);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): CertificateFilter {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCertificateFilter();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.serial = reader.string();
+          break;
+        case 3:
+          message.state = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CertificateFilter {
+    return {
+      $type: CertificateFilter.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      serial: isSet(object.serial) ? String(object.serial) : '',
+      state: isSet(object.state) ? String(object.state) : '',
+    };
+  },
+
+  toJSON(message: CertificateFilter): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.serial !== undefined && (obj.serial = message.serial);
+    message.state !== undefined && (obj.state = message.state);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CertificateFilter>, I>>(
+    object: I,
+  ): CertificateFilter {
+    const message = createBaseCertificateFilter();
+    message.owner = object.owner ?? '';
+    message.serial = object.serial ?? '';
+    message.state = object.state ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(CertificateFilter.$type, CertificateFilter);
+
+function createBaseMsgCreateCertificate(): MsgCreateCertificate {
+  return {
+    $type: 'akash.cert.v1beta1.MsgCreateCertificate',
+    owner: '',
+    cert: new Uint8Array(),
+    pubkey: new Uint8Array(),
+  };
+}
+
+export const MsgCreateCertificate = {
+  $type: 'akash.cert.v1beta1.MsgCreateCertificate' as const,
+
+  encode(
+    message: MsgCreateCertificate,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.cert.length !== 0) {
+      writer.uint32(18).bytes(message.cert);
+    }
+    if (message.pubkey.length !== 0) {
+      writer.uint32(26).bytes(message.pubkey);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCreateCertificate {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateCertificate();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.cert = reader.bytes();
+          break;
+        case 3:
+          message.pubkey = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateCertificate {
+    return {
+      $type: MsgCreateCertificate.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      cert: isSet(object.cert)
+        ? bytesFromBase64(object.cert)
+        : new Uint8Array(),
+      pubkey: isSet(object.pubkey)
+        ? bytesFromBase64(object.pubkey)
+        : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: MsgCreateCertificate): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.cert !== undefined &&
+      (obj.cert = base64FromBytes(
+        message.cert !== undefined ? message.cert : new Uint8Array(),
+      ));
+    message.pubkey !== undefined &&
+      (obj.pubkey = base64FromBytes(
+        message.pubkey !== undefined ? message.pubkey : new Uint8Array(),
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateCertificate>, I>>(
+    object: I,
+  ): MsgCreateCertificate {
+    const message = createBaseMsgCreateCertificate();
+    message.owner = object.owner ?? '';
+    message.cert = object.cert ?? new Uint8Array();
+    message.pubkey = object.pubkey ?? new Uint8Array();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreateCertificate.$type, MsgCreateCertificate);
+
+function createBaseMsgCreateCertificateResponse(): MsgCreateCertificateResponse {
+  return { $type: 'akash.cert.v1beta1.MsgCreateCertificateResponse' };
+}
+
+export const MsgCreateCertificateResponse = {
+  $type: 'akash.cert.v1beta1.MsgCreateCertificateResponse' as const,
+
+  encode(
+    _: MsgCreateCertificateResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCreateCertificateResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateCertificateResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCreateCertificateResponse {
+    return {
+      $type: MsgCreateCertificateResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCreateCertificateResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateCertificateResponse>, I>>(
+    _: I,
+  ): MsgCreateCertificateResponse {
+    const message = createBaseMsgCreateCertificateResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  MsgCreateCertificateResponse.$type,
+  MsgCreateCertificateResponse,
+);
+
+function createBaseMsgRevokeCertificate(): MsgRevokeCertificate {
+  return { $type: 'akash.cert.v1beta1.MsgRevokeCertificate', id: undefined };
+}
+
+export const MsgRevokeCertificate = {
+  $type: 'akash.cert.v1beta1.MsgRevokeCertificate' as const,
+
+  encode(
+    message: MsgRevokeCertificate,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      CertificateID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgRevokeCertificate {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgRevokeCertificate();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = CertificateID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgRevokeCertificate {
+    return {
+      $type: MsgRevokeCertificate.$type,
+      id: isSet(object.id) ? CertificateID.fromJSON(object.id) : undefined,
+    };
+  },
+
+  toJSON(message: MsgRevokeCertificate): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? CertificateID.toJSON(message.id) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgRevokeCertificate>, I>>(
+    object: I,
+  ): MsgRevokeCertificate {
+    const message = createBaseMsgRevokeCertificate();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? CertificateID.fromPartial(object.id)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgRevokeCertificate.$type, MsgRevokeCertificate);
+
+function createBaseMsgRevokeCertificateResponse(): MsgRevokeCertificateResponse {
+  return { $type: 'akash.cert.v1beta1.MsgRevokeCertificateResponse' };
+}
+
+export const MsgRevokeCertificateResponse = {
+  $type: 'akash.cert.v1beta1.MsgRevokeCertificateResponse' as const,
+
+  encode(
+    _: MsgRevokeCertificateResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgRevokeCertificateResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgRevokeCertificateResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgRevokeCertificateResponse {
+    return {
+      $type: MsgRevokeCertificateResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgRevokeCertificateResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgRevokeCertificateResponse>, I>>(
+    _: I,
+  ): MsgRevokeCertificateResponse {
+    const message = createBaseMsgRevokeCertificateResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  MsgRevokeCertificateResponse.$type,
+  MsgRevokeCertificateResponse,
+);
+
+/** Msg defines the provider Msg service */
+export interface Msg {
+  /** CreateCertificate defines a method to create new certificate given proper inputs. */
+  CreateCertificate(
+    request: MsgCreateCertificate,
+  ): Promise<MsgCreateCertificateResponse>;
+  /** RevokeCertificate defines a method to revoke the certificate */
+  RevokeCertificate(
+    request: MsgRevokeCertificate,
+  ): Promise<MsgRevokeCertificateResponse>;
+}
+
+export class MsgClientImpl implements Msg {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.CreateCertificate = this.CreateCertificate.bind(this);
+    this.RevokeCertificate = this.RevokeCertificate.bind(this);
+  }
+  CreateCertificate(
+    request: MsgCreateCertificate,
+  ): Promise<MsgCreateCertificateResponse> {
+    const data = MsgCreateCertificate.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.cert.v1beta1.Msg',
+      'CreateCertificate',
+      data,
+    );
+    return promise.then((data) =>
+      MsgCreateCertificateResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  RevokeCertificate(
+    request: MsgRevokeCertificate,
+  ): Promise<MsgRevokeCertificateResponse> {
+    const data = MsgRevokeCertificate.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.cert.v1beta1.Msg',
+      'RevokeCertificate',
+      data,
+    );
+    return promise.then((data) =>
+      MsgRevokeCertificateResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  for (const byte of arr) {
+    bin.push(String.fromCharCode(byte));
+  }
+  return btoa(bin.join(''));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/cert/v1beta1/genesis.ts
+++ b/ts/src/deprecated/akash/cert/v1beta1/genesis.ts
@@ -1,0 +1,211 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import { Certificate } from '../../../akash/cert/v1beta1/cert';
+
+export const protobufPackage = 'akash.cert.v1beta1';
+
+/** GenesisCertificate defines certificate entry at genesis */
+export interface GenesisCertificate {
+  $type: 'akash.cert.v1beta1.GenesisCertificate';
+  owner: string;
+  certificate?: Certificate;
+}
+
+/** GenesisState defines the basic genesis state used by cert module */
+export interface GenesisState {
+  $type: 'akash.cert.v1beta1.GenesisState';
+  certificates: GenesisCertificate[];
+}
+
+function createBaseGenesisCertificate(): GenesisCertificate {
+  return {
+    $type: 'akash.cert.v1beta1.GenesisCertificate',
+    owner: '',
+    certificate: undefined,
+  };
+}
+
+export const GenesisCertificate = {
+  $type: 'akash.cert.v1beta1.GenesisCertificate' as const,
+
+  encode(
+    message: GenesisCertificate,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.certificate !== undefined) {
+      Certificate.encode(
+        message.certificate,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GenesisCertificate {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisCertificate();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.certificate = Certificate.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GenesisCertificate {
+    return {
+      $type: GenesisCertificate.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      certificate: isSet(object.certificate)
+        ? Certificate.fromJSON(object.certificate)
+        : undefined,
+    };
+  },
+
+  toJSON(message: GenesisCertificate): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.certificate !== undefined &&
+      (obj.certificate = message.certificate
+        ? Certificate.toJSON(message.certificate)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GenesisCertificate>, I>>(
+    object: I,
+  ): GenesisCertificate {
+    const message = createBaseGenesisCertificate();
+    message.owner = object.owner ?? '';
+    message.certificate =
+      object.certificate !== undefined && object.certificate !== null
+        ? Certificate.fromPartial(object.certificate)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(GenesisCertificate.$type, GenesisCertificate);
+
+function createBaseGenesisState(): GenesisState {
+  return { $type: 'akash.cert.v1beta1.GenesisState', certificates: [] };
+}
+
+export const GenesisState = {
+  $type: 'akash.cert.v1beta1.GenesisState' as const,
+
+  encode(
+    message: GenesisState,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.certificates) {
+      GenesisCertificate.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GenesisState {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.certificates.push(
+            GenesisCertificate.decode(reader, reader.uint32()),
+          );
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GenesisState {
+    return {
+      $type: GenesisState.$type,
+      certificates: Array.isArray(object?.certificates)
+        ? object.certificates.map((e: any) => GenesisCertificate.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: GenesisState): unknown {
+    const obj: any = {};
+    if (message.certificates) {
+      obj.certificates = message.certificates.map((e) =>
+        e ? GenesisCertificate.toJSON(e) : undefined,
+      );
+    } else {
+      obj.certificates = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GenesisState>, I>>(
+    object: I,
+  ): GenesisState {
+    const message = createBaseGenesisState();
+    message.certificates =
+      object.certificates?.map((e) => GenesisCertificate.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/cert/v1beta1/query.ts
+++ b/ts/src/deprecated/akash/cert/v1beta1/query.ts
@@ -1,0 +1,390 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import _m0 from 'protobufjs/minimal';
+
+import {
+  Certificate,
+  CertificateFilter,
+} from '../../../akash/cert/v1beta1/cert';
+import Long from 'long';
+import {
+  PageRequest,
+  PageResponse,
+} from '../../../cosmos/base/query/v1beta1/pagination';
+
+export const protobufPackage = 'akash.cert.v1beta1';
+
+export interface CertificateResponse {
+  $type: 'akash.cert.v1beta1.CertificateResponse';
+  certificate?: Certificate;
+  serial: string;
+}
+
+/** QueryDeploymentsRequest is request type for the Query/Deployments RPC method */
+export interface QueryCertificatesRequest {
+  $type: 'akash.cert.v1beta1.QueryCertificatesRequest';
+  filter?: CertificateFilter;
+  pagination?: PageRequest;
+}
+
+/** QueryCertificatesResponse is response type for the Query/Certificates RPC method */
+export interface QueryCertificatesResponse {
+  $type: 'akash.cert.v1beta1.QueryCertificatesResponse';
+  certificates: CertificateResponse[];
+  pagination?: PageResponse;
+}
+
+function createBaseCertificateResponse(): CertificateResponse {
+  return {
+    $type: 'akash.cert.v1beta1.CertificateResponse',
+    certificate: undefined,
+    serial: '',
+  };
+}
+
+export const CertificateResponse = {
+  $type: 'akash.cert.v1beta1.CertificateResponse' as const,
+
+  encode(
+    message: CertificateResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.certificate !== undefined) {
+      Certificate.encode(
+        message.certificate,
+        writer.uint32(10).fork(),
+      ).ldelim();
+    }
+    if (message.serial !== '') {
+      writer.uint32(18).string(message.serial);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): CertificateResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCertificateResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.certificate = Certificate.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.serial = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CertificateResponse {
+    return {
+      $type: CertificateResponse.$type,
+      certificate: isSet(object.certificate)
+        ? Certificate.fromJSON(object.certificate)
+        : undefined,
+      serial: isSet(object.serial) ? String(object.serial) : '',
+    };
+  },
+
+  toJSON(message: CertificateResponse): unknown {
+    const obj: any = {};
+    message.certificate !== undefined &&
+      (obj.certificate = message.certificate
+        ? Certificate.toJSON(message.certificate)
+        : undefined);
+    message.serial !== undefined && (obj.serial = message.serial);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CertificateResponse>, I>>(
+    object: I,
+  ): CertificateResponse {
+    const message = createBaseCertificateResponse();
+    message.certificate =
+      object.certificate !== undefined && object.certificate !== null
+        ? Certificate.fromPartial(object.certificate)
+        : undefined;
+    message.serial = object.serial ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(CertificateResponse.$type, CertificateResponse);
+
+function createBaseQueryCertificatesRequest(): QueryCertificatesRequest {
+  return {
+    $type: 'akash.cert.v1beta1.QueryCertificatesRequest',
+    filter: undefined,
+    pagination: undefined,
+  };
+}
+
+export const QueryCertificatesRequest = {
+  $type: 'akash.cert.v1beta1.QueryCertificatesRequest' as const,
+
+  encode(
+    message: QueryCertificatesRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.filter !== undefined) {
+      CertificateFilter.encode(
+        message.filter,
+        writer.uint32(10).fork(),
+      ).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryCertificatesRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCertificatesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.filter = CertificateFilter.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryCertificatesRequest {
+    return {
+      $type: QueryCertificatesRequest.$type,
+      filter: isSet(object.filter)
+        ? CertificateFilter.fromJSON(object.filter)
+        : undefined,
+      pagination: isSet(object.pagination)
+        ? PageRequest.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryCertificatesRequest): unknown {
+    const obj: any = {};
+    message.filter !== undefined &&
+      (obj.filter = message.filter
+        ? CertificateFilter.toJSON(message.filter)
+        : undefined);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryCertificatesRequest>, I>>(
+    object: I,
+  ): QueryCertificatesRequest {
+    const message = createBaseQueryCertificatesRequest();
+    message.filter =
+      object.filter !== undefined && object.filter !== null
+        ? CertificateFilter.fromPartial(object.filter)
+        : undefined;
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageRequest.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  QueryCertificatesRequest.$type,
+  QueryCertificatesRequest,
+);
+
+function createBaseQueryCertificatesResponse(): QueryCertificatesResponse {
+  return {
+    $type: 'akash.cert.v1beta1.QueryCertificatesResponse',
+    certificates: [],
+    pagination: undefined,
+  };
+}
+
+export const QueryCertificatesResponse = {
+  $type: 'akash.cert.v1beta1.QueryCertificatesResponse' as const,
+
+  encode(
+    message: QueryCertificatesResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.certificates) {
+      CertificateResponse.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryCertificatesResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryCertificatesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.certificates.push(
+            CertificateResponse.decode(reader, reader.uint32()),
+          );
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryCertificatesResponse {
+    return {
+      $type: QueryCertificatesResponse.$type,
+      certificates: Array.isArray(object?.certificates)
+        ? object.certificates.map((e: any) => CertificateResponse.fromJSON(e))
+        : [],
+      pagination: isSet(object.pagination)
+        ? PageResponse.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryCertificatesResponse): unknown {
+    const obj: any = {};
+    if (message.certificates) {
+      obj.certificates = message.certificates.map((e) =>
+        e ? CertificateResponse.toJSON(e) : undefined,
+      );
+    } else {
+      obj.certificates = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryCertificatesResponse>, I>>(
+    object: I,
+  ): QueryCertificatesResponse {
+    const message = createBaseQueryCertificatesResponse();
+    message.certificates =
+      object.certificates?.map((e) => CertificateResponse.fromPartial(e)) || [];
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageResponse.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  QueryCertificatesResponse.$type,
+  QueryCertificatesResponse,
+);
+
+/** Query defines the gRPC querier service */
+export interface Query {
+  /** Certificates queries certificates */
+  Certificates(
+    request: QueryCertificatesRequest,
+  ): Promise<QueryCertificatesResponse>;
+}
+
+export class QueryClientImpl implements Query {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.Certificates = this.Certificates.bind(this);
+  }
+  Certificates(
+    request: QueryCertificatesRequest,
+  ): Promise<QueryCertificatesResponse> {
+    const data = QueryCertificatesRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.cert.v1beta1.Query',
+      'Certificates',
+      data,
+    );
+    return promise.then((data) =>
+      QueryCertificatesResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/deployment/v1beta1/authz.ts
+++ b/ts/src/deprecated/akash/deployment/v1beta1/authz.ts
@@ -1,0 +1,134 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import { Coin } from '../../../cosmos/base/v1beta1/coin';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.deployment.v1beta1';
+
+/**
+ * DepositDeploymentAuthorization allows the grantee to deposit up to spend_limit coins from
+ * the granter's account for a deployment.
+ */
+export interface DepositDeploymentAuthorization {
+  $type: 'akash.deployment.v1beta1.DepositDeploymentAuthorization';
+  /**
+   * SpendLimit is the amount the grantee is authorized to spend from the granter's account for
+   * the purpose of deployment.
+   */
+  spendLimit: Coin | undefined;
+}
+
+function createBaseDepositDeploymentAuthorization(): DepositDeploymentAuthorization {
+  return {
+    $type: 'akash.deployment.v1beta1.DepositDeploymentAuthorization',
+    spendLimit: undefined,
+  };
+}
+
+export const DepositDeploymentAuthorization = {
+  $type: 'akash.deployment.v1beta1.DepositDeploymentAuthorization' as const,
+
+  encode(
+    message: DepositDeploymentAuthorization,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.spendLimit !== undefined) {
+      Coin.encode(message.spendLimit, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): DepositDeploymentAuthorization {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDepositDeploymentAuthorization();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.spendLimit = Coin.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DepositDeploymentAuthorization {
+    return {
+      $type: DepositDeploymentAuthorization.$type,
+      spendLimit: isSet(object.spendLimit)
+        ? Coin.fromJSON(object.spendLimit)
+        : undefined,
+    };
+  },
+
+  toJSON(message: DepositDeploymentAuthorization): unknown {
+    const obj: any = {};
+    message.spendLimit !== undefined &&
+      (obj.spendLimit = message.spendLimit
+        ? Coin.toJSON(message.spendLimit)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DepositDeploymentAuthorization>, I>>(
+    object: I,
+  ): DepositDeploymentAuthorization {
+    const message = createBaseDepositDeploymentAuthorization();
+    message.spendLimit =
+      object.spendLimit !== undefined && object.spendLimit !== null
+        ? Coin.fromPartial(object.spendLimit)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  DepositDeploymentAuthorization.$type,
+  DepositDeploymentAuthorization,
+);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/deployment/v1beta1/deployment.ts
+++ b/ts/src/deprecated/akash/deployment/v1beta1/deployment.ts
@@ -1,0 +1,1210 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import {
+  GroupSpec,
+  MsgCloseGroupResponse,
+  MsgPauseGroupResponse,
+  MsgStartGroupResponse,
+  MsgCloseGroup,
+  MsgPauseGroup,
+  MsgStartGroup,
+} from './group';
+import { Coin } from '../../../cosmos/base/v1beta1/coin';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.deployment.v1beta1';
+
+/** MsgCreateDeployment defines an SDK message for creating deployment */
+export interface MsgCreateDeployment {
+  $type: 'akash.deployment.v1beta1.MsgCreateDeployment';
+  id: DeploymentID | undefined;
+  groups: GroupSpec[];
+  version: Uint8Array;
+  deposit: Coin | undefined;
+}
+
+/** MsgCreateDeploymentResponse defines the Msg/CreateDeployment response type. */
+export interface MsgCreateDeploymentResponse {
+  $type: 'akash.deployment.v1beta1.MsgCreateDeploymentResponse';
+}
+
+/** MsgDepositDeployment deposits more funds into the deposit account */
+export interface MsgDepositDeployment {
+  $type: 'akash.deployment.v1beta1.MsgDepositDeployment';
+  id: DeploymentID | undefined;
+  amount: Coin | undefined;
+}
+
+/** MsgCreateDeploymentResponse defines the Msg/CreateDeployment response type. */
+export interface MsgDepositDeploymentResponse {
+  $type: 'akash.deployment.v1beta1.MsgDepositDeploymentResponse';
+}
+
+/** MsgUpdateDeployment defines an SDK message for updating deployment */
+export interface MsgUpdateDeployment {
+  $type: 'akash.deployment.v1beta1.MsgUpdateDeployment';
+  id: DeploymentID | undefined;
+  groups: GroupSpec[];
+  version: Uint8Array;
+}
+
+/** MsgUpdateDeploymentResponse defines the Msg/UpdateDeployment response type. */
+export interface MsgUpdateDeploymentResponse {
+  $type: 'akash.deployment.v1beta1.MsgUpdateDeploymentResponse';
+}
+
+/** MsgCloseDeployment defines an SDK message for closing deployment */
+export interface MsgCloseDeployment {
+  $type: 'akash.deployment.v1beta1.MsgCloseDeployment';
+  id: DeploymentID | undefined;
+}
+
+/** MsgCloseDeploymentResponse defines the Msg/CloseDeployment response type. */
+export interface MsgCloseDeploymentResponse {
+  $type: 'akash.deployment.v1beta1.MsgCloseDeploymentResponse';
+}
+
+/** DeploymentID stores owner and sequence number */
+export interface DeploymentID {
+  $type: 'akash.deployment.v1beta1.DeploymentID';
+  owner: string;
+  dseq: Long;
+}
+
+/** Deployment stores deploymentID, state and version details */
+export interface Deployment {
+  $type: 'akash.deployment.v1beta1.Deployment';
+  deploymentId: DeploymentID | undefined;
+  state: Deployment_State;
+  version: Uint8Array;
+  createdAt: Long;
+}
+
+/** State is an enum which refers to state of deployment */
+export enum Deployment_State {
+  /** invalid - Prefix should start with 0 in enum. So declaring dummy state */
+  invalid = 0,
+  /** active - DeploymentActive denotes state for deployment active */
+  active = 1,
+  /** closed - DeploymentClosed denotes state for deployment closed */
+  closed = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function deployment_StateFromJSON(object: any): Deployment_State {
+  switch (object) {
+    case 0:
+    case 'invalid':
+      return Deployment_State.invalid;
+    case 1:
+    case 'active':
+      return Deployment_State.active;
+    case 2:
+    case 'closed':
+      return Deployment_State.closed;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Deployment_State.UNRECOGNIZED;
+  }
+}
+
+export function deployment_StateToJSON(object: Deployment_State): string {
+  switch (object) {
+    case Deployment_State.invalid:
+      return 'invalid';
+    case Deployment_State.active:
+      return 'active';
+    case Deployment_State.closed:
+      return 'closed';
+    case Deployment_State.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+/** DeploymentFilters defines filters used to filter deployments */
+export interface DeploymentFilters {
+  $type: 'akash.deployment.v1beta1.DeploymentFilters';
+  owner: string;
+  dseq: Long;
+  state: string;
+}
+
+function createBaseMsgCreateDeployment(): MsgCreateDeployment {
+  return {
+    $type: 'akash.deployment.v1beta1.MsgCreateDeployment',
+    id: undefined,
+    groups: [],
+    version: new Uint8Array(),
+    deposit: undefined,
+  };
+}
+
+export const MsgCreateDeployment = {
+  $type: 'akash.deployment.v1beta1.MsgCreateDeployment' as const,
+
+  encode(
+    message: MsgCreateDeployment,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      DeploymentID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.groups) {
+      GroupSpec.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.version.length !== 0) {
+      writer.uint32(26).bytes(message.version);
+    }
+    if (message.deposit !== undefined) {
+      Coin.encode(message.deposit, writer.uint32(34).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCreateDeployment {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateDeployment();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = DeploymentID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.groups.push(GroupSpec.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.version = reader.bytes();
+          break;
+        case 4:
+          message.deposit = Coin.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateDeployment {
+    return {
+      $type: MsgCreateDeployment.$type,
+      id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
+      groups: Array.isArray(object?.groups)
+        ? object.groups.map((e: any) => GroupSpec.fromJSON(e))
+        : [],
+      version: isSet(object.version)
+        ? bytesFromBase64(object.version)
+        : new Uint8Array(),
+      deposit: isSet(object.deposit)
+        ? Coin.fromJSON(object.deposit)
+        : undefined,
+    };
+  },
+
+  toJSON(message: MsgCreateDeployment): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? DeploymentID.toJSON(message.id) : undefined);
+    if (message.groups) {
+      obj.groups = message.groups.map((e) =>
+        e ? GroupSpec.toJSON(e) : undefined,
+      );
+    } else {
+      obj.groups = [];
+    }
+    message.version !== undefined &&
+      (obj.version = base64FromBytes(
+        message.version !== undefined ? message.version : new Uint8Array(),
+      ));
+    message.deposit !== undefined &&
+      (obj.deposit = message.deposit
+        ? Coin.toJSON(message.deposit)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateDeployment>, I>>(
+    object: I,
+  ): MsgCreateDeployment {
+    const message = createBaseMsgCreateDeployment();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? DeploymentID.fromPartial(object.id)
+        : undefined;
+    message.groups = object.groups?.map((e) => GroupSpec.fromPartial(e)) || [];
+    message.version = object.version ?? new Uint8Array();
+    message.deposit =
+      object.deposit !== undefined && object.deposit !== null
+        ? Coin.fromPartial(object.deposit)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreateDeployment.$type, MsgCreateDeployment);
+
+function createBaseMsgCreateDeploymentResponse(): MsgCreateDeploymentResponse {
+  return { $type: 'akash.deployment.v1beta1.MsgCreateDeploymentResponse' };
+}
+
+export const MsgCreateDeploymentResponse = {
+  $type: 'akash.deployment.v1beta1.MsgCreateDeploymentResponse' as const,
+
+  encode(
+    _: MsgCreateDeploymentResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCreateDeploymentResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateDeploymentResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCreateDeploymentResponse {
+    return {
+      $type: MsgCreateDeploymentResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCreateDeploymentResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateDeploymentResponse>, I>>(
+    _: I,
+  ): MsgCreateDeploymentResponse {
+    const message = createBaseMsgCreateDeploymentResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  MsgCreateDeploymentResponse.$type,
+  MsgCreateDeploymentResponse,
+);
+
+function createBaseMsgDepositDeployment(): MsgDepositDeployment {
+  return {
+    $type: 'akash.deployment.v1beta1.MsgDepositDeployment',
+    id: undefined,
+    amount: undefined,
+  };
+}
+
+export const MsgDepositDeployment = {
+  $type: 'akash.deployment.v1beta1.MsgDepositDeployment' as const,
+
+  encode(
+    message: MsgDepositDeployment,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      DeploymentID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.amount !== undefined) {
+      Coin.encode(message.amount, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgDepositDeployment {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgDepositDeployment();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = DeploymentID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.amount = Coin.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgDepositDeployment {
+    return {
+      $type: MsgDepositDeployment.$type,
+      id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
+      amount: isSet(object.amount) ? Coin.fromJSON(object.amount) : undefined,
+    };
+  },
+
+  toJSON(message: MsgDepositDeployment): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? DeploymentID.toJSON(message.id) : undefined);
+    message.amount !== undefined &&
+      (obj.amount = message.amount ? Coin.toJSON(message.amount) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgDepositDeployment>, I>>(
+    object: I,
+  ): MsgDepositDeployment {
+    const message = createBaseMsgDepositDeployment();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? DeploymentID.fromPartial(object.id)
+        : undefined;
+    message.amount =
+      object.amount !== undefined && object.amount !== null
+        ? Coin.fromPartial(object.amount)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgDepositDeployment.$type, MsgDepositDeployment);
+
+function createBaseMsgDepositDeploymentResponse(): MsgDepositDeploymentResponse {
+  return { $type: 'akash.deployment.v1beta1.MsgDepositDeploymentResponse' };
+}
+
+export const MsgDepositDeploymentResponse = {
+  $type: 'akash.deployment.v1beta1.MsgDepositDeploymentResponse' as const,
+
+  encode(
+    _: MsgDepositDeploymentResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgDepositDeploymentResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgDepositDeploymentResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgDepositDeploymentResponse {
+    return {
+      $type: MsgDepositDeploymentResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgDepositDeploymentResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgDepositDeploymentResponse>, I>>(
+    _: I,
+  ): MsgDepositDeploymentResponse {
+    const message = createBaseMsgDepositDeploymentResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  MsgDepositDeploymentResponse.$type,
+  MsgDepositDeploymentResponse,
+);
+
+function createBaseMsgUpdateDeployment(): MsgUpdateDeployment {
+  return {
+    $type: 'akash.deployment.v1beta1.MsgUpdateDeployment',
+    id: undefined,
+    groups: [],
+    version: new Uint8Array(),
+  };
+}
+
+export const MsgUpdateDeployment = {
+  $type: 'akash.deployment.v1beta1.MsgUpdateDeployment' as const,
+
+  encode(
+    message: MsgUpdateDeployment,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      DeploymentID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.groups) {
+      GroupSpec.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.version.length !== 0) {
+      writer.uint32(26).bytes(message.version);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgUpdateDeployment {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgUpdateDeployment();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = DeploymentID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.groups.push(GroupSpec.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.version = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgUpdateDeployment {
+    return {
+      $type: MsgUpdateDeployment.$type,
+      id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
+      groups: Array.isArray(object?.groups)
+        ? object.groups.map((e: any) => GroupSpec.fromJSON(e))
+        : [],
+      version: isSet(object.version)
+        ? bytesFromBase64(object.version)
+        : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: MsgUpdateDeployment): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? DeploymentID.toJSON(message.id) : undefined);
+    if (message.groups) {
+      obj.groups = message.groups.map((e) =>
+        e ? GroupSpec.toJSON(e) : undefined,
+      );
+    } else {
+      obj.groups = [];
+    }
+    message.version !== undefined &&
+      (obj.version = base64FromBytes(
+        message.version !== undefined ? message.version : new Uint8Array(),
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgUpdateDeployment>, I>>(
+    object: I,
+  ): MsgUpdateDeployment {
+    const message = createBaseMsgUpdateDeployment();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? DeploymentID.fromPartial(object.id)
+        : undefined;
+    message.groups = object.groups?.map((e) => GroupSpec.fromPartial(e)) || [];
+    message.version = object.version ?? new Uint8Array();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgUpdateDeployment.$type, MsgUpdateDeployment);
+
+function createBaseMsgUpdateDeploymentResponse(): MsgUpdateDeploymentResponse {
+  return { $type: 'akash.deployment.v1beta1.MsgUpdateDeploymentResponse' };
+}
+
+export const MsgUpdateDeploymentResponse = {
+  $type: 'akash.deployment.v1beta1.MsgUpdateDeploymentResponse' as const,
+
+  encode(
+    _: MsgUpdateDeploymentResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgUpdateDeploymentResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgUpdateDeploymentResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgUpdateDeploymentResponse {
+    return {
+      $type: MsgUpdateDeploymentResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgUpdateDeploymentResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgUpdateDeploymentResponse>, I>>(
+    _: I,
+  ): MsgUpdateDeploymentResponse {
+    const message = createBaseMsgUpdateDeploymentResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  MsgUpdateDeploymentResponse.$type,
+  MsgUpdateDeploymentResponse,
+);
+
+function createBaseMsgCloseDeployment(): MsgCloseDeployment {
+  return {
+    $type: 'akash.deployment.v1beta1.MsgCloseDeployment',
+    id: undefined,
+  };
+}
+
+export const MsgCloseDeployment = {
+  $type: 'akash.deployment.v1beta1.MsgCloseDeployment' as const,
+
+  encode(
+    message: MsgCloseDeployment,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      DeploymentID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCloseDeployment {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseDeployment();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = DeploymentID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCloseDeployment {
+    return {
+      $type: MsgCloseDeployment.$type,
+      id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
+    };
+  },
+
+  toJSON(message: MsgCloseDeployment): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? DeploymentID.toJSON(message.id) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseDeployment>, I>>(
+    object: I,
+  ): MsgCloseDeployment {
+    const message = createBaseMsgCloseDeployment();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? DeploymentID.fromPartial(object.id)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCloseDeployment.$type, MsgCloseDeployment);
+
+function createBaseMsgCloseDeploymentResponse(): MsgCloseDeploymentResponse {
+  return { $type: 'akash.deployment.v1beta1.MsgCloseDeploymentResponse' };
+}
+
+export const MsgCloseDeploymentResponse = {
+  $type: 'akash.deployment.v1beta1.MsgCloseDeploymentResponse' as const,
+
+  encode(
+    _: MsgCloseDeploymentResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCloseDeploymentResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseDeploymentResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCloseDeploymentResponse {
+    return {
+      $type: MsgCloseDeploymentResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCloseDeploymentResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseDeploymentResponse>, I>>(
+    _: I,
+  ): MsgCloseDeploymentResponse {
+    const message = createBaseMsgCloseDeploymentResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  MsgCloseDeploymentResponse.$type,
+  MsgCloseDeploymentResponse,
+);
+
+function createBaseDeploymentID(): DeploymentID {
+  return {
+    $type: 'akash.deployment.v1beta1.DeploymentID',
+    owner: '',
+    dseq: Long.UZERO,
+  };
+}
+
+export const DeploymentID = {
+  $type: 'akash.deployment.v1beta1.DeploymentID' as const,
+
+  encode(
+    message: DeploymentID,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DeploymentID {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeploymentID();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DeploymentID {
+    return {
+      $type: DeploymentID.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromValue(object.dseq) : Long.UZERO,
+    };
+  },
+
+  toJSON(message: DeploymentID): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DeploymentID>, I>>(
+    object: I,
+  ): DeploymentID {
+    const message = createBaseDeploymentID();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(DeploymentID.$type, DeploymentID);
+
+function createBaseDeployment(): Deployment {
+  return {
+    $type: 'akash.deployment.v1beta1.Deployment',
+    deploymentId: undefined,
+    state: 0,
+    version: new Uint8Array(),
+    createdAt: Long.ZERO,
+  };
+}
+
+export const Deployment = {
+  $type: 'akash.deployment.v1beta1.Deployment' as const,
+
+  encode(
+    message: Deployment,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.deploymentId !== undefined) {
+      DeploymentID.encode(
+        message.deploymentId,
+        writer.uint32(10).fork(),
+      ).ldelim();
+    }
+    if (message.state !== 0) {
+      writer.uint32(16).int32(message.state);
+    }
+    if (message.version.length !== 0) {
+      writer.uint32(26).bytes(message.version);
+    }
+    if (!message.createdAt.isZero()) {
+      writer.uint32(32).int64(message.createdAt);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Deployment {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeployment();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.deploymentId = DeploymentID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.state = reader.int32() as any;
+          break;
+        case 3:
+          message.version = reader.bytes();
+          break;
+        case 4:
+          message.createdAt = reader.int64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Deployment {
+    return {
+      $type: Deployment.$type,
+      deploymentId: isSet(object.deploymentId)
+        ? DeploymentID.fromJSON(object.deploymentId)
+        : undefined,
+      state: isSet(object.state) ? deployment_StateFromJSON(object.state) : 0,
+      version: isSet(object.version)
+        ? bytesFromBase64(object.version)
+        : new Uint8Array(),
+      createdAt: isSet(object.createdAt)
+        ? Long.fromValue(object.createdAt)
+        : Long.ZERO,
+    };
+  },
+
+  toJSON(message: Deployment): unknown {
+    const obj: any = {};
+    message.deploymentId !== undefined &&
+      (obj.deploymentId = message.deploymentId
+        ? DeploymentID.toJSON(message.deploymentId)
+        : undefined);
+    message.state !== undefined &&
+      (obj.state = deployment_StateToJSON(message.state));
+    message.version !== undefined &&
+      (obj.version = base64FromBytes(
+        message.version !== undefined ? message.version : new Uint8Array(),
+      ));
+    message.createdAt !== undefined &&
+      (obj.createdAt = (message.createdAt || Long.ZERO).toString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Deployment>, I>>(
+    object: I,
+  ): Deployment {
+    const message = createBaseDeployment();
+    message.deploymentId =
+      object.deploymentId !== undefined && object.deploymentId !== null
+        ? DeploymentID.fromPartial(object.deploymentId)
+        : undefined;
+    message.state = object.state ?? 0;
+    message.version = object.version ?? new Uint8Array();
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null
+        ? Long.fromValue(object.createdAt)
+        : Long.ZERO;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Deployment.$type, Deployment);
+
+function createBaseDeploymentFilters(): DeploymentFilters {
+  return {
+    $type: 'akash.deployment.v1beta1.DeploymentFilters',
+    owner: '',
+    dseq: Long.UZERO,
+    state: '',
+  };
+}
+
+export const DeploymentFilters = {
+  $type: 'akash.deployment.v1beta1.DeploymentFilters' as const,
+
+  encode(
+    message: DeploymentFilters,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.state !== '') {
+      writer.uint32(26).string(message.state);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DeploymentFilters {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDeploymentFilters();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.state = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DeploymentFilters {
+    return {
+      $type: DeploymentFilters.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromValue(object.dseq) : Long.UZERO,
+      state: isSet(object.state) ? String(object.state) : '',
+    };
+  },
+
+  toJSON(message: DeploymentFilters): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.state !== undefined && (obj.state = message.state);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DeploymentFilters>, I>>(
+    object: I,
+  ): DeploymentFilters {
+    const message = createBaseDeploymentFilters();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.state = object.state ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(DeploymentFilters.$type, DeploymentFilters);
+
+/** Msg defines the deployment Msg service. */
+export interface Msg {
+  /** CreateDeployment defines a method to create new deployment given proper inputs. */
+  CreateDeployment(
+    request: MsgCreateDeployment,
+  ): Promise<MsgCreateDeploymentResponse>;
+  /** DepositDeployment deposits more funds into the deployment account */
+  DepositDeployment(
+    request: MsgDepositDeployment,
+  ): Promise<MsgDepositDeploymentResponse>;
+  /** UpdateDeployment defines a method to update a deployment given proper inputs. */
+  UpdateDeployment(
+    request: MsgUpdateDeployment,
+  ): Promise<MsgUpdateDeploymentResponse>;
+  /** CloseDeployment defines a method to close a deployment given proper inputs. */
+  CloseDeployment(
+    request: MsgCloseDeployment,
+  ): Promise<MsgCloseDeploymentResponse>;
+  /** CloseGroup defines a method to close a group of a deployment given proper inputs. */
+  CloseGroup(request: MsgCloseGroup): Promise<MsgCloseGroupResponse>;
+  /** PauseGroup defines a method to close a group of a deployment given proper inputs. */
+  PauseGroup(request: MsgPauseGroup): Promise<MsgPauseGroupResponse>;
+  /** StartGroup defines a method to close a group of a deployment given proper inputs. */
+  StartGroup(request: MsgStartGroup): Promise<MsgStartGroupResponse>;
+}
+
+export class MsgClientImpl implements Msg {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.CreateDeployment = this.CreateDeployment.bind(this);
+    this.DepositDeployment = this.DepositDeployment.bind(this);
+    this.UpdateDeployment = this.UpdateDeployment.bind(this);
+    this.CloseDeployment = this.CloseDeployment.bind(this);
+    this.CloseGroup = this.CloseGroup.bind(this);
+    this.PauseGroup = this.PauseGroup.bind(this);
+    this.StartGroup = this.StartGroup.bind(this);
+  }
+  CreateDeployment(
+    request: MsgCreateDeployment,
+  ): Promise<MsgCreateDeploymentResponse> {
+    const data = MsgCreateDeployment.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Msg',
+      'CreateDeployment',
+      data,
+    );
+    return promise.then((data) =>
+      MsgCreateDeploymentResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  DepositDeployment(
+    request: MsgDepositDeployment,
+  ): Promise<MsgDepositDeploymentResponse> {
+    const data = MsgDepositDeployment.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Msg',
+      'DepositDeployment',
+      data,
+    );
+    return promise.then((data) =>
+      MsgDepositDeploymentResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  UpdateDeployment(
+    request: MsgUpdateDeployment,
+  ): Promise<MsgUpdateDeploymentResponse> {
+    const data = MsgUpdateDeployment.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Msg',
+      'UpdateDeployment',
+      data,
+    );
+    return promise.then((data) =>
+      MsgUpdateDeploymentResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  CloseDeployment(
+    request: MsgCloseDeployment,
+  ): Promise<MsgCloseDeploymentResponse> {
+    const data = MsgCloseDeployment.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Msg',
+      'CloseDeployment',
+      data,
+    );
+    return promise.then((data) =>
+      MsgCloseDeploymentResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  CloseGroup(request: MsgCloseGroup): Promise<MsgCloseGroupResponse> {
+    const data = MsgCloseGroup.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Msg',
+      'CloseGroup',
+      data,
+    );
+    return promise.then((data) =>
+      MsgCloseGroupResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  PauseGroup(request: MsgPauseGroup): Promise<MsgPauseGroupResponse> {
+    const data = MsgPauseGroup.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Msg',
+      'PauseGroup',
+      data,
+    );
+    return promise.then((data) =>
+      MsgPauseGroupResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  StartGroup(request: MsgStartGroup): Promise<MsgStartGroupResponse> {
+    const data = MsgStartGroup.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Msg',
+      'StartGroup',
+      data,
+    );
+    return promise.then((data) =>
+      MsgStartGroupResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  arr.forEach((byte) => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return btoa(bin.join(''));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/deployment/v1beta1/genesis.ts
+++ b/ts/src/deprecated/akash/deployment/v1beta1/genesis.ts
@@ -1,0 +1,234 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import { Deployment } from './deployment';
+import { Group } from './group';
+import { Params } from './params';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.deployment.v1beta1';
+
+/** GenesisDeployment defines the basic genesis state used by deployment module */
+export interface GenesisDeployment {
+  $type: 'akash.deployment.v1beta1.GenesisDeployment';
+  deployment: Deployment | undefined;
+  groups: Group[];
+}
+
+/** GenesisState stores slice of genesis deployment instance */
+export interface GenesisState {
+  $type: 'akash.deployment.v1beta1.GenesisState';
+  deployments: GenesisDeployment[];
+  params: Params | undefined;
+}
+
+function createBaseGenesisDeployment(): GenesisDeployment {
+  return {
+    $type: 'akash.deployment.v1beta1.GenesisDeployment',
+    deployment: undefined,
+    groups: [],
+  };
+}
+
+export const GenesisDeployment = {
+  $type: 'akash.deployment.v1beta1.GenesisDeployment' as const,
+
+  encode(
+    message: GenesisDeployment,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.deployment !== undefined) {
+      Deployment.encode(message.deployment, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.groups) {
+      Group.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GenesisDeployment {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisDeployment();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.deployment = Deployment.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.groups.push(Group.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GenesisDeployment {
+    return {
+      $type: GenesisDeployment.$type,
+      deployment: isSet(object.deployment)
+        ? Deployment.fromJSON(object.deployment)
+        : undefined,
+      groups: Array.isArray(object?.groups)
+        ? object.groups.map((e: any) => Group.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: GenesisDeployment): unknown {
+    const obj: any = {};
+    message.deployment !== undefined &&
+      (obj.deployment = message.deployment
+        ? Deployment.toJSON(message.deployment)
+        : undefined);
+    if (message.groups) {
+      obj.groups = message.groups.map((e) => (e ? Group.toJSON(e) : undefined));
+    } else {
+      obj.groups = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GenesisDeployment>, I>>(
+    object: I,
+  ): GenesisDeployment {
+    const message = createBaseGenesisDeployment();
+    message.deployment =
+      object.deployment !== undefined && object.deployment !== null
+        ? Deployment.fromPartial(object.deployment)
+        : undefined;
+    message.groups = object.groups?.map((e) => Group.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(GenesisDeployment.$type, GenesisDeployment);
+
+function createBaseGenesisState(): GenesisState {
+  return {
+    $type: 'akash.deployment.v1beta1.GenesisState',
+    deployments: [],
+    params: undefined,
+  };
+}
+
+export const GenesisState = {
+  $type: 'akash.deployment.v1beta1.GenesisState' as const,
+
+  encode(
+    message: GenesisState,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.deployments) {
+      GenesisDeployment.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.params !== undefined) {
+      Params.encode(message.params, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GenesisState {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGenesisState();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.deployments.push(
+            GenesisDeployment.decode(reader, reader.uint32()),
+          );
+          break;
+        case 2:
+          message.params = Params.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GenesisState {
+    return {
+      $type: GenesisState.$type,
+      deployments: Array.isArray(object?.deployments)
+        ? object.deployments.map((e: any) => GenesisDeployment.fromJSON(e))
+        : [],
+      params: isSet(object.params) ? Params.fromJSON(object.params) : undefined,
+    };
+  },
+
+  toJSON(message: GenesisState): unknown {
+    const obj: any = {};
+    if (message.deployments) {
+      obj.deployments = message.deployments.map((e) =>
+        e ? GenesisDeployment.toJSON(e) : undefined,
+      );
+    } else {
+      obj.deployments = [];
+    }
+    message.params !== undefined &&
+      (obj.params = message.params ? Params.toJSON(message.params) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GenesisState>, I>>(
+    object: I,
+  ): GenesisState {
+    const message = createBaseGenesisState();
+    message.deployments =
+      object.deployments?.map((e) => GenesisDeployment.fromPartial(e)) || [];
+    message.params =
+      object.params !== undefined && object.params !== null
+        ? Params.fromPartial(object.params)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(GenesisState.$type, GenesisState);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/deployment/v1beta1/group.ts
+++ b/ts/src/deprecated/akash/deployment/v1beta1/group.ts
@@ -1,0 +1,912 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import { PlacementRequirements } from '../../base/v1beta1/attribute';
+import { ResourceUnits } from '../../base/v1beta1/resource';
+import { Coin } from '../../../cosmos/base/v1beta1/coin';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.deployment.v1beta1';
+
+/** MsgCloseGroup defines SDK message to close a single Group within a Deployment. */
+export interface MsgCloseGroup {
+  $type: 'akash.deployment.v1beta1.MsgCloseGroup';
+  id: GroupID | undefined;
+}
+
+/** MsgCloseGroupResponse defines the Msg/CloseGroup response type. */
+export interface MsgCloseGroupResponse {
+  $type: 'akash.deployment.v1beta1.MsgCloseGroupResponse';
+}
+
+/** MsgPauseGroup defines SDK message to close a single Group within a Deployment. */
+export interface MsgPauseGroup {
+  $type: 'akash.deployment.v1beta1.MsgPauseGroup';
+  id: GroupID | undefined;
+}
+
+/** MsgPauseGroupResponse defines the Msg/PauseGroup response type. */
+export interface MsgPauseGroupResponse {
+  $type: 'akash.deployment.v1beta1.MsgPauseGroupResponse';
+}
+
+/** MsgStartGroup defines SDK message to close a single Group within a Deployment. */
+export interface MsgStartGroup {
+  $type: 'akash.deployment.v1beta1.MsgStartGroup';
+  id: GroupID | undefined;
+}
+
+/** MsgStartGroupResponse defines the Msg/StartGroup response type. */
+export interface MsgStartGroupResponse {
+  $type: 'akash.deployment.v1beta1.MsgStartGroupResponse';
+}
+
+/** GroupID stores owner, deployment sequence number and group sequence number */
+export interface GroupID {
+  $type: 'akash.deployment.v1beta1.GroupID';
+  owner: string;
+  dseq: Long;
+  gseq: number;
+}
+
+/** GroupSpec stores group specifications */
+export interface GroupSpec {
+  $type: 'akash.deployment.v1beta1.GroupSpec';
+  name: string;
+  requirements: PlacementRequirements | undefined;
+  resources: Resource[];
+}
+
+/** Group stores group id, state and specifications of group */
+export interface Group {
+  $type: 'akash.deployment.v1beta1.Group';
+  groupId: GroupID | undefined;
+  state: Group_State;
+  groupSpec: GroupSpec | undefined;
+  createdAt: Long;
+}
+
+/** State is an enum which refers to state of group */
+export enum Group_State {
+  /** invalid - Prefix should start with 0 in enum. So declaring dummy state */
+  invalid = 0,
+  /** open - GroupOpen denotes state for group open */
+  open = 1,
+  /** paused - GroupOrdered denotes state for group ordered */
+  paused = 2,
+  /** insufficient_funds - GroupInsufficientFunds denotes state for group insufficient_funds */
+  insufficient_funds = 3,
+  /** closed - GroupClosed denotes state for group closed */
+  closed = 4,
+  UNRECOGNIZED = -1,
+}
+
+export function group_StateFromJSON(object: any): Group_State {
+  switch (object) {
+    case 0:
+    case 'invalid':
+      return Group_State.invalid;
+    case 1:
+    case 'open':
+      return Group_State.open;
+    case 2:
+    case 'paused':
+      return Group_State.paused;
+    case 3:
+    case 'insufficient_funds':
+      return Group_State.insufficient_funds;
+    case 4:
+    case 'closed':
+      return Group_State.closed;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Group_State.UNRECOGNIZED;
+  }
+}
+
+export function group_StateToJSON(object: Group_State): string {
+  switch (object) {
+    case Group_State.invalid:
+      return 'invalid';
+    case Group_State.open:
+      return 'open';
+    case Group_State.paused:
+      return 'paused';
+    case Group_State.insufficient_funds:
+      return 'insufficient_funds';
+    case Group_State.closed:
+      return 'closed';
+    case Group_State.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
+
+/** Resource stores unit, total count and price of resource */
+export interface Resource {
+  $type: 'akash.deployment.v1beta1.Resource';
+  resources: ResourceUnits | undefined;
+  count: number;
+  price: Coin | undefined;
+}
+
+function createBaseMsgCloseGroup(): MsgCloseGroup {
+  return { $type: 'akash.deployment.v1beta1.MsgCloseGroup', id: undefined };
+}
+
+export const MsgCloseGroup = {
+  $type: 'akash.deployment.v1beta1.MsgCloseGroup' as const,
+
+  encode(
+    message: MsgCloseGroup,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      GroupID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCloseGroup {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseGroup();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = GroupID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCloseGroup {
+    return {
+      $type: MsgCloseGroup.$type,
+      id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
+    };
+  },
+
+  toJSON(message: MsgCloseGroup): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? GroupID.toJSON(message.id) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseGroup>, I>>(
+    object: I,
+  ): MsgCloseGroup {
+    const message = createBaseMsgCloseGroup();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? GroupID.fromPartial(object.id)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCloseGroup.$type, MsgCloseGroup);
+
+function createBaseMsgCloseGroupResponse(): MsgCloseGroupResponse {
+  return { $type: 'akash.deployment.v1beta1.MsgCloseGroupResponse' };
+}
+
+export const MsgCloseGroupResponse = {
+  $type: 'akash.deployment.v1beta1.MsgCloseGroupResponse' as const,
+
+  encode(
+    _: MsgCloseGroupResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCloseGroupResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseGroupResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCloseGroupResponse {
+    return {
+      $type: MsgCloseGroupResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCloseGroupResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseGroupResponse>, I>>(
+    _: I,
+  ): MsgCloseGroupResponse {
+    const message = createBaseMsgCloseGroupResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCloseGroupResponse.$type, MsgCloseGroupResponse);
+
+function createBaseMsgPauseGroup(): MsgPauseGroup {
+  return { $type: 'akash.deployment.v1beta1.MsgPauseGroup', id: undefined };
+}
+
+export const MsgPauseGroup = {
+  $type: 'akash.deployment.v1beta1.MsgPauseGroup' as const,
+
+  encode(
+    message: MsgPauseGroup,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      GroupID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgPauseGroup {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgPauseGroup();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = GroupID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgPauseGroup {
+    return {
+      $type: MsgPauseGroup.$type,
+      id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
+    };
+  },
+
+  toJSON(message: MsgPauseGroup): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? GroupID.toJSON(message.id) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgPauseGroup>, I>>(
+    object: I,
+  ): MsgPauseGroup {
+    const message = createBaseMsgPauseGroup();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? GroupID.fromPartial(object.id)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgPauseGroup.$type, MsgPauseGroup);
+
+function createBaseMsgPauseGroupResponse(): MsgPauseGroupResponse {
+  return { $type: 'akash.deployment.v1beta1.MsgPauseGroupResponse' };
+}
+
+export const MsgPauseGroupResponse = {
+  $type: 'akash.deployment.v1beta1.MsgPauseGroupResponse' as const,
+
+  encode(
+    _: MsgPauseGroupResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgPauseGroupResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgPauseGroupResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgPauseGroupResponse {
+    return {
+      $type: MsgPauseGroupResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgPauseGroupResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgPauseGroupResponse>, I>>(
+    _: I,
+  ): MsgPauseGroupResponse {
+    const message = createBaseMsgPauseGroupResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgPauseGroupResponse.$type, MsgPauseGroupResponse);
+
+function createBaseMsgStartGroup(): MsgStartGroup {
+  return { $type: 'akash.deployment.v1beta1.MsgStartGroup', id: undefined };
+}
+
+export const MsgStartGroup = {
+  $type: 'akash.deployment.v1beta1.MsgStartGroup' as const,
+
+  encode(
+    message: MsgStartGroup,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      GroupID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgStartGroup {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgStartGroup();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = GroupID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgStartGroup {
+    return {
+      $type: MsgStartGroup.$type,
+      id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
+    };
+  },
+
+  toJSON(message: MsgStartGroup): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? GroupID.toJSON(message.id) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgStartGroup>, I>>(
+    object: I,
+  ): MsgStartGroup {
+    const message = createBaseMsgStartGroup();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? GroupID.fromPartial(object.id)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgStartGroup.$type, MsgStartGroup);
+
+function createBaseMsgStartGroupResponse(): MsgStartGroupResponse {
+  return { $type: 'akash.deployment.v1beta1.MsgStartGroupResponse' };
+}
+
+export const MsgStartGroupResponse = {
+  $type: 'akash.deployment.v1beta1.MsgStartGroupResponse' as const,
+
+  encode(
+    _: MsgStartGroupResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgStartGroupResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgStartGroupResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgStartGroupResponse {
+    return {
+      $type: MsgStartGroupResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgStartGroupResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgStartGroupResponse>, I>>(
+    _: I,
+  ): MsgStartGroupResponse {
+    const message = createBaseMsgStartGroupResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgStartGroupResponse.$type, MsgStartGroupResponse);
+
+function createBaseGroupID(): GroupID {
+  return {
+    $type: 'akash.deployment.v1beta1.GroupID',
+    owner: '',
+    dseq: Long.UZERO,
+    gseq: 0,
+  };
+}
+
+export const GroupID = {
+  $type: 'akash.deployment.v1beta1.GroupID' as const,
+
+  encode(
+    message: GroupID,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.gseq !== 0) {
+      writer.uint32(24).uint32(message.gseq);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GroupID {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGroupID();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.gseq = reader.uint32();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GroupID {
+    return {
+      $type: GroupID.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromValue(object.dseq) : Long.UZERO,
+      gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
+    };
+  },
+
+  toJSON(message: GroupID): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.gseq !== undefined && (obj.gseq = Math.round(message.gseq));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GroupID>, I>>(object: I): GroupID {
+    const message = createBaseGroupID();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.gseq = object.gseq ?? 0;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(GroupID.$type, GroupID);
+
+function createBaseGroupSpec(): GroupSpec {
+  return {
+    $type: 'akash.deployment.v1beta1.GroupSpec',
+    name: '',
+    requirements: undefined,
+    resources: [],
+  };
+}
+
+export const GroupSpec = {
+  $type: 'akash.deployment.v1beta1.GroupSpec' as const,
+
+  encode(
+    message: GroupSpec,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.name !== '') {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.requirements !== undefined) {
+      PlacementRequirements.encode(
+        message.requirements,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    for (const v of message.resources) {
+      Resource.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GroupSpec {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGroupSpec();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.name = reader.string();
+          break;
+        case 2:
+          message.requirements = PlacementRequirements.decode(
+            reader,
+            reader.uint32(),
+          );
+          break;
+        case 3:
+          message.resources.push(Resource.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GroupSpec {
+    return {
+      $type: GroupSpec.$type,
+      name: isSet(object.name) ? String(object.name) : '',
+      requirements: isSet(object.requirements)
+        ? PlacementRequirements.fromJSON(object.requirements)
+        : undefined,
+      resources: Array.isArray(object?.resources)
+        ? object.resources.map((e: any) => Resource.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: GroupSpec): unknown {
+    const obj: any = {};
+    message.name !== undefined && (obj.name = message.name);
+    message.requirements !== undefined &&
+      (obj.requirements = message.requirements
+        ? PlacementRequirements.toJSON(message.requirements)
+        : undefined);
+    if (message.resources) {
+      obj.resources = message.resources.map((e) =>
+        e ? Resource.toJSON(e) : undefined,
+      );
+    } else {
+      obj.resources = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<GroupSpec>, I>>(
+    object: I,
+  ): GroupSpec {
+    const message = createBaseGroupSpec();
+    message.name = object.name ?? '';
+    message.requirements =
+      object.requirements !== undefined && object.requirements !== null
+        ? PlacementRequirements.fromPartial(object.requirements)
+        : undefined;
+    message.resources =
+      object.resources?.map((e) => Resource.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(GroupSpec.$type, GroupSpec);
+
+function createBaseGroup(): Group {
+  return {
+    $type: 'akash.deployment.v1beta1.Group',
+    groupId: undefined,
+    state: 0,
+    groupSpec: undefined,
+    createdAt: Long.ZERO,
+  };
+}
+
+export const Group = {
+  $type: 'akash.deployment.v1beta1.Group' as const,
+
+  encode(message: Group, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.groupId !== undefined) {
+      GroupID.encode(message.groupId, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.state !== 0) {
+      writer.uint32(16).int32(message.state);
+    }
+    if (message.groupSpec !== undefined) {
+      GroupSpec.encode(message.groupSpec, writer.uint32(26).fork()).ldelim();
+    }
+    if (!message.createdAt.isZero()) {
+      writer.uint32(32).int64(message.createdAt);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Group {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGroup();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.groupId = GroupID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.state = reader.int32() as any;
+          break;
+        case 3:
+          message.groupSpec = GroupSpec.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.createdAt = reader.int64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Group {
+    return {
+      $type: Group.$type,
+      groupId: isSet(object.groupId)
+        ? GroupID.fromJSON(object.groupId)
+        : undefined,
+      state: isSet(object.state) ? group_StateFromJSON(object.state) : 0,
+      groupSpec: isSet(object.groupSpec)
+        ? GroupSpec.fromJSON(object.groupSpec)
+        : undefined,
+      createdAt: isSet(object.createdAt)
+        ? Long.fromValue(object.createdAt)
+        : Long.ZERO,
+    };
+  },
+
+  toJSON(message: Group): unknown {
+    const obj: any = {};
+    message.groupId !== undefined &&
+      (obj.groupId = message.groupId
+        ? GroupID.toJSON(message.groupId)
+        : undefined);
+    message.state !== undefined &&
+      (obj.state = group_StateToJSON(message.state));
+    message.groupSpec !== undefined &&
+      (obj.groupSpec = message.groupSpec
+        ? GroupSpec.toJSON(message.groupSpec)
+        : undefined);
+    message.createdAt !== undefined &&
+      (obj.createdAt = (message.createdAt || Long.ZERO).toString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Group>, I>>(object: I): Group {
+    const message = createBaseGroup();
+    message.groupId =
+      object.groupId !== undefined && object.groupId !== null
+        ? GroupID.fromPartial(object.groupId)
+        : undefined;
+    message.state = object.state ?? 0;
+    message.groupSpec =
+      object.groupSpec !== undefined && object.groupSpec !== null
+        ? GroupSpec.fromPartial(object.groupSpec)
+        : undefined;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null
+        ? Long.fromValue(object.createdAt)
+        : Long.ZERO;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Group.$type, Group);
+
+function createBaseResource(): Resource {
+  return {
+    $type: 'akash.deployment.v1beta1.Resource',
+    resources: undefined,
+    count: 0,
+    price: undefined,
+  };
+}
+
+export const Resource = {
+  $type: 'akash.deployment.v1beta1.Resource' as const,
+
+  encode(
+    message: Resource,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.resources !== undefined) {
+      ResourceUnits.encode(
+        message.resources,
+        writer.uint32(10).fork(),
+      ).ldelim();
+    }
+    if (message.count !== 0) {
+      writer.uint32(16).uint32(message.count);
+    }
+    if (message.price !== undefined) {
+      Coin.encode(message.price, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Resource {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseResource();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.resources = ResourceUnits.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.count = reader.uint32();
+          break;
+        case 3:
+          message.price = Coin.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Resource {
+    return {
+      $type: Resource.$type,
+      resources: isSet(object.resources)
+        ? ResourceUnits.fromJSON(object.resources)
+        : undefined,
+      count: isSet(object.count) ? Number(object.count) : 0,
+      price: isSet(object.price) ? Coin.fromJSON(object.price) : undefined,
+    };
+  },
+
+  toJSON(message: Resource): unknown {
+    const obj: any = {};
+    message.resources !== undefined &&
+      (obj.resources = message.resources
+        ? ResourceUnits.toJSON(message.resources)
+        : undefined);
+    message.count !== undefined && (obj.count = Math.round(message.count));
+    message.price !== undefined &&
+      (obj.price = message.price ? Coin.toJSON(message.price) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Resource>, I>>(object: I): Resource {
+    const message = createBaseResource();
+    message.resources =
+      object.resources !== undefined && object.resources !== null
+        ? ResourceUnits.fromPartial(object.resources)
+        : undefined;
+    message.count = object.count ?? 0;
+    message.price =
+      object.price !== undefined && object.price !== null
+        ? Coin.fromPartial(object.price)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Resource.$type, Resource);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/deployment/v1beta1/params.ts
+++ b/ts/src/deprecated/akash/deployment/v1beta1/params.ts
@@ -1,0 +1,123 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import { Coin } from '../../../cosmos/base/v1beta1/coin';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'akash.deployment.v1beta1';
+
+/** Params defines the parameters for the x/deployment package */
+export interface Params {
+  $type: 'akash.deployment.v1beta1.Params';
+  deploymentMinDeposit: Coin | undefined;
+}
+
+function createBaseParams(): Params {
+  return {
+    $type: 'akash.deployment.v1beta1.Params',
+    deploymentMinDeposit: undefined,
+  };
+}
+
+export const Params = {
+  $type: 'akash.deployment.v1beta1.Params' as const,
+
+  encode(
+    message: Params,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.deploymentMinDeposit !== undefined) {
+      Coin.encode(
+        message.deploymentMinDeposit,
+        writer.uint32(10).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Params {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseParams();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.deploymentMinDeposit = Coin.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Params {
+    return {
+      $type: Params.$type,
+      deploymentMinDeposit: isSet(object.deploymentMinDeposit)
+        ? Coin.fromJSON(object.deploymentMinDeposit)
+        : undefined,
+    };
+  },
+
+  toJSON(message: Params): unknown {
+    const obj: any = {};
+    message.deploymentMinDeposit !== undefined &&
+      (obj.deploymentMinDeposit = message.deploymentMinDeposit
+        ? Coin.toJSON(message.deploymentMinDeposit)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Params>, I>>(object: I): Params {
+    const message = createBaseParams();
+    message.deploymentMinDeposit =
+      object.deploymentMinDeposit !== undefined &&
+      object.deploymentMinDeposit !== null
+        ? Coin.fromPartial(object.deploymentMinDeposit)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Params.$type, Params);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/deployment/v1beta1/query.ts
+++ b/ts/src/deprecated/akash/deployment/v1beta1/query.ts
@@ -1,0 +1,662 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import { DeploymentFilters, DeploymentID, Deployment } from './deployment';
+import {
+  PageRequest,
+  PageResponse,
+} from '../../../cosmos/base/query/v1beta1/pagination';
+import * as _m0 from 'protobufjs/minimal';
+import { Group, GroupID } from './group';
+import { Account } from '../../../../generated/akash/escrow/v1beta1/types';
+
+export const protobufPackage = 'akash.deployment.v1beta1';
+
+/** QueryDeploymentsRequest is request type for the Query/Deployments RPC method */
+export interface QueryDeploymentsRequest {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentsRequest';
+  filters: DeploymentFilters | undefined;
+  pagination: PageRequest | undefined;
+}
+
+/** QueryDeploymentsResponse is response type for the Query/Deployments RPC method */
+export interface QueryDeploymentsResponse {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentsResponse';
+  deployments: QueryDeploymentResponse[];
+  pagination: PageResponse | undefined;
+}
+
+/** QueryDeploymentRequest is request type for the Query/Deployment RPC method */
+export interface QueryDeploymentRequest {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentRequest';
+  id: DeploymentID | undefined;
+}
+
+/** QueryDeploymentResponse is response type for the Query/Deployment RPC method */
+export interface QueryDeploymentResponse {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentResponse';
+  deployment: Deployment | undefined;
+  groups: Group[];
+  escrowAccount: Account | undefined;
+}
+
+/** QueryGroupRequest is request type for the Query/Group RPC method */
+export interface QueryGroupRequest {
+  $type: 'akash.deployment.v1beta1.QueryGroupRequest';
+  id: GroupID | undefined;
+}
+
+/** QueryGroupResponse is response type for the Query/Group RPC method */
+export interface QueryGroupResponse {
+  $type: 'akash.deployment.v1beta1.QueryGroupResponse';
+  group: Group | undefined;
+}
+
+function createBaseQueryDeploymentsRequest(): QueryDeploymentsRequest {
+  return {
+    $type: 'akash.deployment.v1beta1.QueryDeploymentsRequest',
+    filters: undefined,
+    pagination: undefined,
+  };
+}
+
+export const QueryDeploymentsRequest = {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentsRequest' as const,
+
+  encode(
+    message: QueryDeploymentsRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.filters !== undefined) {
+      DeploymentFilters.encode(
+        message.filters,
+        writer.uint32(10).fork(),
+      ).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryDeploymentsRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryDeploymentsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.filters = DeploymentFilters.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryDeploymentsRequest {
+    return {
+      $type: QueryDeploymentsRequest.$type,
+      filters: isSet(object.filters)
+        ? DeploymentFilters.fromJSON(object.filters)
+        : undefined,
+      pagination: isSet(object.pagination)
+        ? PageRequest.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryDeploymentsRequest): unknown {
+    const obj: any = {};
+    message.filters !== undefined &&
+      (obj.filters = message.filters
+        ? DeploymentFilters.toJSON(message.filters)
+        : undefined);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryDeploymentsRequest>, I>>(
+    object: I,
+  ): QueryDeploymentsRequest {
+    const message = createBaseQueryDeploymentsRequest();
+    message.filters =
+      object.filters !== undefined && object.filters !== null
+        ? DeploymentFilters.fromPartial(object.filters)
+        : undefined;
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageRequest.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryDeploymentsRequest.$type, QueryDeploymentsRequest);
+
+function createBaseQueryDeploymentsResponse(): QueryDeploymentsResponse {
+  return {
+    $type: 'akash.deployment.v1beta1.QueryDeploymentsResponse',
+    deployments: [],
+    pagination: undefined,
+  };
+}
+
+export const QueryDeploymentsResponse = {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentsResponse' as const,
+
+  encode(
+    message: QueryDeploymentsResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.deployments) {
+      QueryDeploymentResponse.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryDeploymentsResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryDeploymentsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.deployments.push(
+            QueryDeploymentResponse.decode(reader, reader.uint32()),
+          );
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryDeploymentsResponse {
+    return {
+      $type: QueryDeploymentsResponse.$type,
+      deployments: Array.isArray(object?.deployments)
+        ? object.deployments.map((e: any) =>
+            QueryDeploymentResponse.fromJSON(e),
+          )
+        : [],
+      pagination: isSet(object.pagination)
+        ? PageResponse.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryDeploymentsResponse): unknown {
+    const obj: any = {};
+    if (message.deployments) {
+      obj.deployments = message.deployments.map((e) =>
+        e ? QueryDeploymentResponse.toJSON(e) : undefined,
+      );
+    } else {
+      obj.deployments = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryDeploymentsResponse>, I>>(
+    object: I,
+  ): QueryDeploymentsResponse {
+    const message = createBaseQueryDeploymentsResponse();
+    message.deployments =
+      object.deployments?.map((e) => QueryDeploymentResponse.fromPartial(e)) ||
+      [];
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageResponse.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  QueryDeploymentsResponse.$type,
+  QueryDeploymentsResponse,
+);
+
+function createBaseQueryDeploymentRequest(): QueryDeploymentRequest {
+  return {
+    $type: 'akash.deployment.v1beta1.QueryDeploymentRequest',
+    id: undefined,
+  };
+}
+
+export const QueryDeploymentRequest = {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentRequest' as const,
+
+  encode(
+    message: QueryDeploymentRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      DeploymentID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryDeploymentRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryDeploymentRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = DeploymentID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryDeploymentRequest {
+    return {
+      $type: QueryDeploymentRequest.$type,
+      id: isSet(object.id) ? DeploymentID.fromJSON(object.id) : undefined,
+    };
+  },
+
+  toJSON(message: QueryDeploymentRequest): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? DeploymentID.toJSON(message.id) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryDeploymentRequest>, I>>(
+    object: I,
+  ): QueryDeploymentRequest {
+    const message = createBaseQueryDeploymentRequest();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? DeploymentID.fromPartial(object.id)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryDeploymentRequest.$type, QueryDeploymentRequest);
+
+function createBaseQueryDeploymentResponse(): QueryDeploymentResponse {
+  return {
+    $type: 'akash.deployment.v1beta1.QueryDeploymentResponse',
+    deployment: undefined,
+    groups: [],
+    escrowAccount: undefined,
+  };
+}
+
+export const QueryDeploymentResponse = {
+  $type: 'akash.deployment.v1beta1.QueryDeploymentResponse' as const,
+
+  encode(
+    message: QueryDeploymentResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.deployment !== undefined) {
+      Deployment.encode(message.deployment, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.groups) {
+      Group.encode(v!, writer.uint32(18).fork()).ldelim();
+    }
+    if (message.escrowAccount !== undefined) {
+      Account.encode(message.escrowAccount, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryDeploymentResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryDeploymentResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.deployment = Deployment.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.groups.push(Group.decode(reader, reader.uint32()));
+          break;
+        case 3:
+          message.escrowAccount = Account.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryDeploymentResponse {
+    return {
+      $type: QueryDeploymentResponse.$type,
+      deployment: isSet(object.deployment)
+        ? Deployment.fromJSON(object.deployment)
+        : undefined,
+      groups: Array.isArray(object?.groups)
+        ? object.groups.map((e: any) => Group.fromJSON(e))
+        : [],
+      escrowAccount: isSet(object.escrowAccount)
+        ? Account.fromJSON(object.escrowAccount)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryDeploymentResponse): unknown {
+    const obj: any = {};
+    message.deployment !== undefined &&
+      (obj.deployment = message.deployment
+        ? Deployment.toJSON(message.deployment)
+        : undefined);
+    if (message.groups) {
+      obj.groups = message.groups.map((e) => (e ? Group.toJSON(e) : undefined));
+    } else {
+      obj.groups = [];
+    }
+    message.escrowAccount !== undefined &&
+      (obj.escrowAccount = message.escrowAccount
+        ? Account.toJSON(message.escrowAccount)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryDeploymentResponse>, I>>(
+    object: I,
+  ): QueryDeploymentResponse {
+    const message = createBaseQueryDeploymentResponse();
+    message.deployment =
+      object.deployment !== undefined && object.deployment !== null
+        ? Deployment.fromPartial(object.deployment)
+        : undefined;
+    message.groups = object.groups?.map((e) => Group.fromPartial(e)) || [];
+    message.escrowAccount =
+      object.escrowAccount !== undefined && object.escrowAccount !== null
+        ? Account.fromPartial(object.escrowAccount)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryDeploymentResponse.$type, QueryDeploymentResponse);
+
+function createBaseQueryGroupRequest(): QueryGroupRequest {
+  return { $type: 'akash.deployment.v1beta1.QueryGroupRequest', id: undefined };
+}
+
+export const QueryGroupRequest = {
+  $type: 'akash.deployment.v1beta1.QueryGroupRequest' as const,
+
+  encode(
+    message: QueryGroupRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== undefined) {
+      GroupID.encode(message.id, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryGroupRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryGroupRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = GroupID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupRequest {
+    return {
+      $type: QueryGroupRequest.$type,
+      id: isSet(object.id) ? GroupID.fromJSON(object.id) : undefined,
+    };
+  },
+
+  toJSON(message: QueryGroupRequest): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = message.id ? GroupID.toJSON(message.id) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryGroupRequest>, I>>(
+    object: I,
+  ): QueryGroupRequest {
+    const message = createBaseQueryGroupRequest();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? GroupID.fromPartial(object.id)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryGroupRequest.$type, QueryGroupRequest);
+
+function createBaseQueryGroupResponse(): QueryGroupResponse {
+  return {
+    $type: 'akash.deployment.v1beta1.QueryGroupResponse',
+    group: undefined,
+  };
+}
+
+export const QueryGroupResponse = {
+  $type: 'akash.deployment.v1beta1.QueryGroupResponse' as const,
+
+  encode(
+    message: QueryGroupResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.group !== undefined) {
+      Group.encode(message.group, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryGroupResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryGroupResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.group = Group.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryGroupResponse {
+    return {
+      $type: QueryGroupResponse.$type,
+      group: isSet(object.group) ? Group.fromJSON(object.group) : undefined,
+    };
+  },
+
+  toJSON(message: QueryGroupResponse): unknown {
+    const obj: any = {};
+    message.group !== undefined &&
+      (obj.group = message.group ? Group.toJSON(message.group) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryGroupResponse>, I>>(
+    object: I,
+  ): QueryGroupResponse {
+    const message = createBaseQueryGroupResponse();
+    message.group =
+      object.group !== undefined && object.group !== null
+        ? Group.fromPartial(object.group)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryGroupResponse.$type, QueryGroupResponse);
+
+/** Query defines the gRPC querier service */
+export interface Query {
+  /** Deployments queries deployments */
+  Deployments(
+    request: QueryDeploymentsRequest,
+  ): Promise<QueryDeploymentsResponse>;
+  /** Deployment queries deployment details */
+  Deployment(request: QueryDeploymentRequest): Promise<QueryDeploymentResponse>;
+  /** Group queries group details */
+  Group(request: QueryGroupRequest): Promise<QueryGroupResponse>;
+}
+
+export class QueryClientImpl implements Query {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.Deployments = this.Deployments.bind(this);
+    this.Deployment = this.Deployment.bind(this);
+    this.Group = this.Group.bind(this);
+  }
+  Deployments(
+    request: QueryDeploymentsRequest,
+  ): Promise<QueryDeploymentsResponse> {
+    const data = QueryDeploymentsRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Query',
+      'Deployments',
+      data,
+    );
+    return promise.then((data) =>
+      QueryDeploymentsResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  Deployment(
+    request: QueryDeploymentRequest,
+  ): Promise<QueryDeploymentResponse> {
+    const data = QueryDeploymentRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Query',
+      'Deployment',
+      data,
+    );
+    return promise.then((data) =>
+      QueryDeploymentResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  Group(request: QueryGroupRequest): Promise<QueryGroupResponse> {
+    const data = QueryGroupRequest.encode(request).finish();
+    const promise = this.rpc.request(
+      'akash.deployment.v1beta1.Query',
+      'Group',
+      data,
+    );
+    return promise.then((data) =>
+      QueryGroupResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/market/v1beta1/bid.ts
+++ b/ts/src/deprecated/akash/market/v1beta1/bid.ts
@@ -1,0 +1,752 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import { OrderID } from '../../../akash/market/v1beta1/order';
+import { Coin } from '../../../cosmos/base/v1beta1/coin';
+
+export const protobufPackage = 'akash.market.v1beta1';
+
+/** MsgCreateBid defines an SDK message for creating Bid */
+export interface MsgCreateBid {
+  $type: 'akash.market.v1beta1.MsgCreateBid';
+  order?: OrderID;
+  provider: string;
+  price?: Coin;
+  deposit?: Coin;
+}
+
+/** MsgCreateBidResponse defines the Msg/CreateBid response type. */
+export interface MsgCreateBidResponse {
+  $type: 'akash.market.v1beta1.MsgCreateBidResponse';
+}
+
+/** MsgCloseBid defines an SDK message for closing bid */
+export interface MsgCloseBid {
+  $type: 'akash.market.v1beta1.MsgCloseBid';
+  bidId?: BidID;
+}
+
+/** MsgCloseBidResponse defines the Msg/CloseBid response type. */
+export interface MsgCloseBidResponse {
+  $type: 'akash.market.v1beta1.MsgCloseBidResponse';
+}
+
+/**
+ * BidID stores owner and all other seq numbers
+ * A successful bid becomes a Lease(ID).
+ */
+export interface BidID {
+  $type: 'akash.market.v1beta1.BidID';
+  owner: string;
+  dseq: Long;
+  gseq: number;
+  oseq: number;
+  provider: string;
+}
+
+/** Bid stores BidID, state of bid and price */
+export interface Bid {
+  $type: 'akash.market.v1beta1.Bid';
+  bidId?: BidID;
+  state: Bid_State;
+  price?: Coin;
+  createdAt: Long;
+}
+
+/** State is an enum which refers to state of bid */
+export enum Bid_State {
+  /** invalid - Prefix should start with 0 in enum. So declaring dummy state */
+  invalid = 0,
+  /** open - BidOpen denotes state for bid open */
+  open = 1,
+  /** active - BidMatched denotes state for bid open */
+  active = 2,
+  /** lost - BidLost denotes state for bid lost */
+  lost = 3,
+  /** closed - BidClosed denotes state for bid closed */
+  closed = 4,
+  UNRECOGNIZED = -1,
+}
+
+export function bid_StateFromJSON(object: any): Bid_State {
+  switch (object) {
+    case 0:
+    case 'invalid':
+      return Bid_State.invalid;
+    case 1:
+    case 'open':
+      return Bid_State.open;
+    case 2:
+    case 'active':
+      return Bid_State.active;
+    case 3:
+    case 'lost':
+      return Bid_State.lost;
+    case 4:
+    case 'closed':
+      return Bid_State.closed;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Bid_State.UNRECOGNIZED;
+  }
+}
+
+export function bid_StateToJSON(object: Bid_State): string {
+  switch (object) {
+    case Bid_State.invalid:
+      return 'invalid';
+    case Bid_State.open:
+      return 'open';
+    case Bid_State.active:
+      return 'active';
+    case Bid_State.lost:
+      return 'lost';
+    case Bid_State.closed:
+      return 'closed';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+/** BidFilters defines flags for bid list filter */
+export interface BidFilters {
+  $type: 'akash.market.v1beta1.BidFilters';
+  owner: string;
+  dseq: Long;
+  gseq: number;
+  oseq: number;
+  provider: string;
+  state: string;
+}
+
+function createBaseMsgCreateBid(): MsgCreateBid {
+  return {
+    $type: 'akash.market.v1beta1.MsgCreateBid',
+    order: undefined,
+    provider: '',
+    price: undefined,
+    deposit: undefined,
+  };
+}
+
+export const MsgCreateBid = {
+  $type: 'akash.market.v1beta1.MsgCreateBid' as const,
+
+  encode(
+    message: MsgCreateBid,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.order !== undefined) {
+      OrderID.encode(message.order, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.provider !== '') {
+      writer.uint32(18).string(message.provider);
+    }
+    if (message.price !== undefined) {
+      Coin.encode(message.price, writer.uint32(26).fork()).ldelim();
+    }
+    if (message.deposit !== undefined) {
+      Coin.encode(message.deposit, writer.uint32(34).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCreateBid {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateBid();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.order = OrderID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.provider = reader.string();
+          break;
+        case 3:
+          message.price = Coin.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.deposit = Coin.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateBid {
+    return {
+      $type: MsgCreateBid.$type,
+      order: isSet(object.order) ? OrderID.fromJSON(object.order) : undefined,
+      provider: isSet(object.provider) ? String(object.provider) : '',
+      price: isSet(object.price) ? Coin.fromJSON(object.price) : undefined,
+      deposit: isSet(object.deposit)
+        ? Coin.fromJSON(object.deposit)
+        : undefined,
+    };
+  },
+
+  toJSON(message: MsgCreateBid): unknown {
+    const obj: any = {};
+    message.order !== undefined &&
+      (obj.order = message.order ? OrderID.toJSON(message.order) : undefined);
+    message.provider !== undefined && (obj.provider = message.provider);
+    message.price !== undefined &&
+      (obj.price = message.price ? Coin.toJSON(message.price) : undefined);
+    message.deposit !== undefined &&
+      (obj.deposit = message.deposit
+        ? Coin.toJSON(message.deposit)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateBid>, I>>(
+    object: I,
+  ): MsgCreateBid {
+    const message = createBaseMsgCreateBid();
+    message.order =
+      object.order !== undefined && object.order !== null
+        ? OrderID.fromPartial(object.order)
+        : undefined;
+    message.provider = object.provider ?? '';
+    message.price =
+      object.price !== undefined && object.price !== null
+        ? Coin.fromPartial(object.price)
+        : undefined;
+    message.deposit =
+      object.deposit !== undefined && object.deposit !== null
+        ? Coin.fromPartial(object.deposit)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreateBid.$type, MsgCreateBid);
+
+function createBaseMsgCreateBidResponse(): MsgCreateBidResponse {
+  return { $type: 'akash.market.v1beta1.MsgCreateBidResponse' };
+}
+
+export const MsgCreateBidResponse = {
+  $type: 'akash.market.v1beta1.MsgCreateBidResponse' as const,
+
+  encode(
+    _: MsgCreateBidResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCreateBidResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateBidResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCreateBidResponse {
+    return {
+      $type: MsgCreateBidResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCreateBidResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateBidResponse>, I>>(
+    _: I,
+  ): MsgCreateBidResponse {
+    const message = createBaseMsgCreateBidResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreateBidResponse.$type, MsgCreateBidResponse);
+
+function createBaseMsgCloseBid(): MsgCloseBid {
+  return { $type: 'akash.market.v1beta1.MsgCloseBid', bidId: undefined };
+}
+
+export const MsgCloseBid = {
+  $type: 'akash.market.v1beta1.MsgCloseBid' as const,
+
+  encode(
+    message: MsgCloseBid,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.bidId !== undefined) {
+      BidID.encode(message.bidId, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCloseBid {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseBid();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.bidId = BidID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCloseBid {
+    return {
+      $type: MsgCloseBid.$type,
+      bidId: isSet(object.bidId) ? BidID.fromJSON(object.bidId) : undefined,
+    };
+  },
+
+  toJSON(message: MsgCloseBid): unknown {
+    const obj: any = {};
+    message.bidId !== undefined &&
+      (obj.bidId = message.bidId ? BidID.toJSON(message.bidId) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseBid>, I>>(
+    object: I,
+  ): MsgCloseBid {
+    const message = createBaseMsgCloseBid();
+    message.bidId =
+      object.bidId !== undefined && object.bidId !== null
+        ? BidID.fromPartial(object.bidId)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCloseBid.$type, MsgCloseBid);
+
+function createBaseMsgCloseBidResponse(): MsgCloseBidResponse {
+  return { $type: 'akash.market.v1beta1.MsgCloseBidResponse' };
+}
+
+export const MsgCloseBidResponse = {
+  $type: 'akash.market.v1beta1.MsgCloseBidResponse' as const,
+
+  encode(
+    _: MsgCloseBidResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCloseBidResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseBidResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCloseBidResponse {
+    return {
+      $type: MsgCloseBidResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCloseBidResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseBidResponse>, I>>(
+    _: I,
+  ): MsgCloseBidResponse {
+    const message = createBaseMsgCloseBidResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCloseBidResponse.$type, MsgCloseBidResponse);
+
+function createBaseBidID(): BidID {
+  return {
+    $type: 'akash.market.v1beta1.BidID',
+    owner: '',
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    provider: '',
+  };
+}
+
+export const BidID = {
+  $type: 'akash.market.v1beta1.BidID' as const,
+
+  encode(message: BidID, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.gseq !== 0) {
+      writer.uint32(24).uint32(message.gseq);
+    }
+    if (message.oseq !== 0) {
+      writer.uint32(32).uint32(message.oseq);
+    }
+    if (message.provider !== '') {
+      writer.uint32(42).string(message.provider);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BidID {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBidID();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.gseq = reader.uint32();
+          break;
+        case 4:
+          message.oseq = reader.uint32();
+          break;
+        case 5:
+          message.provider = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BidID {
+    return {
+      $type: BidID.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
+      gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
+      oseq: isSet(object.oseq) ? Number(object.oseq) : 0,
+      provider: isSet(object.provider) ? String(object.provider) : '',
+    };
+  },
+
+  toJSON(message: BidID): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.gseq !== undefined && (obj.gseq = Math.round(message.gseq));
+    message.oseq !== undefined && (obj.oseq = Math.round(message.oseq));
+    message.provider !== undefined && (obj.provider = message.provider);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<BidID>, I>>(object: I): BidID {
+    const message = createBaseBidID();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.gseq = object.gseq ?? 0;
+    message.oseq = object.oseq ?? 0;
+    message.provider = object.provider ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(BidID.$type, BidID);
+
+function createBaseBid(): Bid {
+  return {
+    $type: 'akash.market.v1beta1.Bid',
+    bidId: undefined,
+    state: 0,
+    price: undefined,
+    createdAt: Long.ZERO,
+  };
+}
+
+export const Bid = {
+  $type: 'akash.market.v1beta1.Bid' as const,
+
+  encode(message: Bid, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.bidId !== undefined) {
+      BidID.encode(message.bidId, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.state !== 0) {
+      writer.uint32(16).int32(message.state);
+    }
+    if (message.price !== undefined) {
+      Coin.encode(message.price, writer.uint32(26).fork()).ldelim();
+    }
+    if (!message.createdAt.isZero()) {
+      writer.uint32(32).int64(message.createdAt);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Bid {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBid();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.bidId = BidID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.state = reader.int32() as any;
+          break;
+        case 3:
+          message.price = Coin.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.createdAt = reader.int64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Bid {
+    return {
+      $type: Bid.$type,
+      bidId: isSet(object.bidId) ? BidID.fromJSON(object.bidId) : undefined,
+      state: isSet(object.state) ? bid_StateFromJSON(object.state) : 0,
+      price: isSet(object.price) ? Coin.fromJSON(object.price) : undefined,
+      createdAt: isSet(object.createdAt)
+        ? Long.fromString(object.createdAt)
+        : Long.ZERO,
+    };
+  },
+
+  toJSON(message: Bid): unknown {
+    const obj: any = {};
+    message.bidId !== undefined &&
+      (obj.bidId = message.bidId ? BidID.toJSON(message.bidId) : undefined);
+    message.state !== undefined && (obj.state = bid_StateToJSON(message.state));
+    message.price !== undefined &&
+      (obj.price = message.price ? Coin.toJSON(message.price) : undefined);
+    message.createdAt !== undefined &&
+      (obj.createdAt = (message.createdAt || Long.ZERO).toString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Bid>, I>>(object: I): Bid {
+    const message = createBaseBid();
+    message.bidId =
+      object.bidId !== undefined && object.bidId !== null
+        ? BidID.fromPartial(object.bidId)
+        : undefined;
+    message.state = object.state ?? 0;
+    message.price =
+      object.price !== undefined && object.price !== null
+        ? Coin.fromPartial(object.price)
+        : undefined;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null
+        ? Long.fromValue(object.createdAt)
+        : Long.ZERO;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Bid.$type, Bid);
+
+function createBaseBidFilters(): BidFilters {
+  return {
+    $type: 'akash.market.v1beta1.BidFilters',
+    owner: '',
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    provider: '',
+    state: '',
+  };
+}
+
+export const BidFilters = {
+  $type: 'akash.market.v1beta1.BidFilters' as const,
+
+  encode(
+    message: BidFilters,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.gseq !== 0) {
+      writer.uint32(24).uint32(message.gseq);
+    }
+    if (message.oseq !== 0) {
+      writer.uint32(32).uint32(message.oseq);
+    }
+    if (message.provider !== '') {
+      writer.uint32(42).string(message.provider);
+    }
+    if (message.state !== '') {
+      writer.uint32(50).string(message.state);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BidFilters {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBidFilters();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.gseq = reader.uint32();
+          break;
+        case 4:
+          message.oseq = reader.uint32();
+          break;
+        case 5:
+          message.provider = reader.string();
+          break;
+        case 6:
+          message.state = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BidFilters {
+    return {
+      $type: BidFilters.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
+      gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
+      oseq: isSet(object.oseq) ? Number(object.oseq) : 0,
+      provider: isSet(object.provider) ? String(object.provider) : '',
+      state: isSet(object.state) ? String(object.state) : '',
+    };
+  },
+
+  toJSON(message: BidFilters): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.gseq !== undefined && (obj.gseq = Math.round(message.gseq));
+    message.oseq !== undefined && (obj.oseq = Math.round(message.oseq));
+    message.provider !== undefined && (obj.provider = message.provider);
+    message.state !== undefined && (obj.state = message.state);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<BidFilters>, I>>(
+    object: I,
+  ): BidFilters {
+    const message = createBaseBidFilters();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.gseq = object.gseq ?? 0;
+    message.oseq = object.oseq ?? 0;
+    message.provider = object.provider ?? '';
+    message.state = object.state ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(BidFilters.$type, BidFilters);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/market/v1beta1/lease.ts
+++ b/ts/src/deprecated/akash/market/v1beta1/lease.ts
@@ -1,0 +1,837 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import { Coin } from '../../../cosmos/base/v1beta1/coin';
+import { BidID } from '../../../akash/market/v1beta1/bid';
+
+/** LeaseID stores bid details of lease */
+export interface LeaseID {
+  $type: 'akash.market.v1beta1.LeaseID';
+  owner: string;
+  dseq: Long;
+  gseq: number;
+  oseq: number;
+  provider: string;
+}
+
+/** Lease stores LeaseID, state of lease and price */
+export interface Lease {
+  $type: 'akash.market.v1beta1.Lease';
+  leaseId?: LeaseID;
+  state: Lease_State;
+  price?: Coin;
+  createdAt: Long;
+}
+
+/** State is an enum which refers to state of lease */
+export enum Lease_State {
+  /** invalid - Prefix should start with 0 in enum. So declaring dummy state */
+  invalid = 0,
+  /** active - LeaseActive denotes state for lease active */
+  active = 1,
+  /** insufficient_funds - LeaseInsufficientFunds denotes state for lease insufficient_funds */
+  insufficient_funds = 2,
+  /** closed - LeaseClosed denotes state for lease closed */
+  closed = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function lease_StateFromJSON(object: any): Lease_State {
+  switch (object) {
+    case 0:
+    case 'invalid':
+      return Lease_State.invalid;
+    case 1:
+    case 'active':
+      return Lease_State.active;
+    case 2:
+    case 'insufficient_funds':
+      return Lease_State.insufficient_funds;
+    case 3:
+    case 'closed':
+      return Lease_State.closed;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Lease_State.UNRECOGNIZED;
+  }
+}
+
+export function lease_StateToJSON(object: Lease_State): string {
+  switch (object) {
+    case Lease_State.invalid:
+      return 'invalid';
+    case Lease_State.active:
+      return 'active';
+    case Lease_State.insufficient_funds:
+      return 'insufficient_funds';
+    case Lease_State.closed:
+      return 'closed';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+/** LeaseFilters defines flags for lease list filter */
+export interface LeaseFilters {
+  $type: 'akash.market.v1beta1.LeaseFilters';
+  owner: string;
+  dseq: Long;
+  gseq: number;
+  oseq: number;
+  provider: string;
+  state: string;
+}
+
+/** MsgCreateLease is sent to create a lease */
+export interface MsgCreateLease {
+  $type: 'akash.market.v1beta1.MsgCreateLease';
+  bidId?: BidID;
+}
+
+/** MsgCreateLeaseResponse is the response from creating a lease */
+export interface MsgCreateLeaseResponse {
+  $type: 'akash.market.v1beta1.MsgCreateLeaseResponse';
+}
+
+/** MsgWithdrawLease defines an SDK message for closing bid */
+export interface MsgWithdrawLease {
+  $type: 'akash.market.v1beta1.MsgWithdrawLease';
+  bidId?: LeaseID;
+}
+
+/** MsgWithdrawLeaseResponse defines the Msg/WithdrawLease response type. */
+export interface MsgWithdrawLeaseResponse {
+  $type: 'akash.market.v1beta1.MsgWithdrawLeaseResponse';
+}
+
+/** MsgCloseLease defines an SDK message for closing order */
+export interface MsgCloseLease {
+  $type: 'akash.market.v1beta1.MsgCloseLease';
+  leaseId?: LeaseID;
+}
+
+/** MsgCloseLeaseResponse defines the Msg/CloseLease response type. */
+export interface MsgCloseLeaseResponse {
+  $type: 'akash.market.v1beta1.MsgCloseLeaseResponse';
+}
+
+function createBaseLeaseID(): LeaseID {
+  return {
+    $type: 'akash.market.v1beta1.LeaseID',
+    owner: '',
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    provider: '',
+  };
+}
+
+export const LeaseID = {
+  $type: 'akash.market.v1beta1.LeaseID' as const,
+
+  encode(
+    message: LeaseID,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.gseq !== 0) {
+      writer.uint32(24).uint32(message.gseq);
+    }
+    if (message.oseq !== 0) {
+      writer.uint32(32).uint32(message.oseq);
+    }
+    if (message.provider !== '') {
+      writer.uint32(42).string(message.provider);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): LeaseID {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLeaseID();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.gseq = reader.uint32();
+          break;
+        case 4:
+          message.oseq = reader.uint32();
+          break;
+        case 5:
+          message.provider = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): LeaseID {
+    return {
+      $type: LeaseID.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
+      gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
+      oseq: isSet(object.oseq) ? Number(object.oseq) : 0,
+      provider: isSet(object.provider) ? String(object.provider) : '',
+    };
+  },
+
+  toJSON(message: LeaseID): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.gseq !== undefined && (obj.gseq = Math.round(message.gseq));
+    message.oseq !== undefined && (obj.oseq = Math.round(message.oseq));
+    message.provider !== undefined && (obj.provider = message.provider);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<LeaseID>, I>>(object: I): LeaseID {
+    const message = createBaseLeaseID();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.gseq = object.gseq ?? 0;
+    message.oseq = object.oseq ?? 0;
+    message.provider = object.provider ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(LeaseID.$type, LeaseID);
+
+function createBaseLease(): Lease {
+  return {
+    $type: 'akash.market.v1beta1.Lease',
+    leaseId: undefined,
+    state: 0,
+    price: undefined,
+    createdAt: Long.ZERO,
+  };
+}
+
+export const Lease = {
+  $type: 'akash.market.v1beta1.Lease' as const,
+
+  encode(message: Lease, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.leaseId !== undefined) {
+      LeaseID.encode(message.leaseId, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.state !== 0) {
+      writer.uint32(16).int32(message.state);
+    }
+    if (message.price !== undefined) {
+      Coin.encode(message.price, writer.uint32(26).fork()).ldelim();
+    }
+    if (!message.createdAt.isZero()) {
+      writer.uint32(32).int64(message.createdAt);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Lease {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLease();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.leaseId = LeaseID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.state = reader.int32() as any;
+          break;
+        case 3:
+          message.price = Coin.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.createdAt = reader.int64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Lease {
+    return {
+      $type: Lease.$type,
+      leaseId: isSet(object.leaseId)
+        ? LeaseID.fromJSON(object.leaseId)
+        : undefined,
+      state: isSet(object.state) ? lease_StateFromJSON(object.state) : 0,
+      price: isSet(object.price) ? Coin.fromJSON(object.price) : undefined,
+      createdAt: isSet(object.createdAt)
+        ? Long.fromString(object.createdAt)
+        : Long.ZERO,
+    };
+  },
+
+  toJSON(message: Lease): unknown {
+    const obj: any = {};
+    message.leaseId !== undefined &&
+      (obj.leaseId = message.leaseId
+        ? LeaseID.toJSON(message.leaseId)
+        : undefined);
+    message.state !== undefined &&
+      (obj.state = lease_StateToJSON(message.state));
+    message.price !== undefined &&
+      (obj.price = message.price ? Coin.toJSON(message.price) : undefined);
+    message.createdAt !== undefined &&
+      (obj.createdAt = (message.createdAt || Long.ZERO).toString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Lease>, I>>(object: I): Lease {
+    const message = createBaseLease();
+    message.leaseId =
+      object.leaseId !== undefined && object.leaseId !== null
+        ? LeaseID.fromPartial(object.leaseId)
+        : undefined;
+    message.state = object.state ?? 0;
+    message.price =
+      object.price !== undefined && object.price !== null
+        ? Coin.fromPartial(object.price)
+        : undefined;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null
+        ? Long.fromValue(object.createdAt)
+        : Long.ZERO;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Lease.$type, Lease);
+
+function createBaseLeaseFilters(): LeaseFilters {
+  return {
+    $type: 'akash.market.v1beta1.LeaseFilters',
+    owner: '',
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    provider: '',
+    state: '',
+  };
+}
+
+export const LeaseFilters = {
+  $type: 'akash.market.v1beta1.LeaseFilters' as const,
+
+  encode(
+    message: LeaseFilters,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.gseq !== 0) {
+      writer.uint32(24).uint32(message.gseq);
+    }
+    if (message.oseq !== 0) {
+      writer.uint32(32).uint32(message.oseq);
+    }
+    if (message.provider !== '') {
+      writer.uint32(42).string(message.provider);
+    }
+    if (message.state !== '') {
+      writer.uint32(50).string(message.state);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): LeaseFilters {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseLeaseFilters();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.gseq = reader.uint32();
+          break;
+        case 4:
+          message.oseq = reader.uint32();
+          break;
+        case 5:
+          message.provider = reader.string();
+          break;
+        case 6:
+          message.state = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): LeaseFilters {
+    return {
+      $type: LeaseFilters.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
+      gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
+      oseq: isSet(object.oseq) ? Number(object.oseq) : 0,
+      provider: isSet(object.provider) ? String(object.provider) : '',
+      state: isSet(object.state) ? String(object.state) : '',
+    };
+  },
+
+  toJSON(message: LeaseFilters): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.gseq !== undefined && (obj.gseq = Math.round(message.gseq));
+    message.oseq !== undefined && (obj.oseq = Math.round(message.oseq));
+    message.provider !== undefined && (obj.provider = message.provider);
+    message.state !== undefined && (obj.state = message.state);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<LeaseFilters>, I>>(
+    object: I,
+  ): LeaseFilters {
+    const message = createBaseLeaseFilters();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.gseq = object.gseq ?? 0;
+    message.oseq = object.oseq ?? 0;
+    message.provider = object.provider ?? '';
+    message.state = object.state ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(LeaseFilters.$type, LeaseFilters);
+
+function createBaseMsgCreateLease(): MsgCreateLease {
+  return { $type: 'akash.market.v1beta1.MsgCreateLease', bidId: undefined };
+}
+
+export const MsgCreateLease = {
+  $type: 'akash.market.v1beta1.MsgCreateLease' as const,
+
+  encode(
+    message: MsgCreateLease,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.bidId !== undefined) {
+      BidID.encode(message.bidId, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCreateLease {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateLease();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.bidId = BidID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateLease {
+    return {
+      $type: MsgCreateLease.$type,
+      bidId: isSet(object.bidId) ? BidID.fromJSON(object.bidId) : undefined,
+    };
+  },
+
+  toJSON(message: MsgCreateLease): unknown {
+    const obj: any = {};
+    message.bidId !== undefined &&
+      (obj.bidId = message.bidId ? BidID.toJSON(message.bidId) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateLease>, I>>(
+    object: I,
+  ): MsgCreateLease {
+    const message = createBaseMsgCreateLease();
+    message.bidId =
+      object.bidId !== undefined && object.bidId !== null
+        ? BidID.fromPartial(object.bidId)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreateLease.$type, MsgCreateLease);
+
+function createBaseMsgCreateLeaseResponse(): MsgCreateLeaseResponse {
+  return { $type: 'akash.market.v1beta1.MsgCreateLeaseResponse' };
+}
+
+export const MsgCreateLeaseResponse = {
+  $type: 'akash.market.v1beta1.MsgCreateLeaseResponse' as const,
+
+  encode(
+    _: MsgCreateLeaseResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCreateLeaseResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateLeaseResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCreateLeaseResponse {
+    return {
+      $type: MsgCreateLeaseResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCreateLeaseResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateLeaseResponse>, I>>(
+    _: I,
+  ): MsgCreateLeaseResponse {
+    const message = createBaseMsgCreateLeaseResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreateLeaseResponse.$type, MsgCreateLeaseResponse);
+
+function createBaseMsgWithdrawLease(): MsgWithdrawLease {
+  return { $type: 'akash.market.v1beta1.MsgWithdrawLease', bidId: undefined };
+}
+
+export const MsgWithdrawLease = {
+  $type: 'akash.market.v1beta1.MsgWithdrawLease' as const,
+
+  encode(
+    message: MsgWithdrawLease,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.bidId !== undefined) {
+      LeaseID.encode(message.bidId, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgWithdrawLease {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgWithdrawLease();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.bidId = LeaseID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgWithdrawLease {
+    return {
+      $type: MsgWithdrawLease.$type,
+      bidId: isSet(object.bidId) ? LeaseID.fromJSON(object.bidId) : undefined,
+    };
+  },
+
+  toJSON(message: MsgWithdrawLease): unknown {
+    const obj: any = {};
+    message.bidId !== undefined &&
+      (obj.bidId = message.bidId ? LeaseID.toJSON(message.bidId) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgWithdrawLease>, I>>(
+    object: I,
+  ): MsgWithdrawLease {
+    const message = createBaseMsgWithdrawLease();
+    message.bidId =
+      object.bidId !== undefined && object.bidId !== null
+        ? LeaseID.fromPartial(object.bidId)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgWithdrawLease.$type, MsgWithdrawLease);
+
+function createBaseMsgWithdrawLeaseResponse(): MsgWithdrawLeaseResponse {
+  return { $type: 'akash.market.v1beta1.MsgWithdrawLeaseResponse' };
+}
+
+export const MsgWithdrawLeaseResponse = {
+  $type: 'akash.market.v1beta1.MsgWithdrawLeaseResponse' as const,
+
+  encode(
+    _: MsgWithdrawLeaseResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgWithdrawLeaseResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgWithdrawLeaseResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgWithdrawLeaseResponse {
+    return {
+      $type: MsgWithdrawLeaseResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgWithdrawLeaseResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgWithdrawLeaseResponse>, I>>(
+    _: I,
+  ): MsgWithdrawLeaseResponse {
+    const message = createBaseMsgWithdrawLeaseResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  MsgWithdrawLeaseResponse.$type,
+  MsgWithdrawLeaseResponse,
+);
+
+function createBaseMsgCloseLease(): MsgCloseLease {
+  return { $type: 'akash.market.v1beta1.MsgCloseLease', leaseId: undefined };
+}
+
+export const MsgCloseLease = {
+  $type: 'akash.market.v1beta1.MsgCloseLease' as const,
+
+  encode(
+    message: MsgCloseLease,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.leaseId !== undefined) {
+      LeaseID.encode(message.leaseId, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCloseLease {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseLease();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.leaseId = LeaseID.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCloseLease {
+    return {
+      $type: MsgCloseLease.$type,
+      leaseId: isSet(object.leaseId)
+        ? LeaseID.fromJSON(object.leaseId)
+        : undefined,
+    };
+  },
+
+  toJSON(message: MsgCloseLease): unknown {
+    const obj: any = {};
+    message.leaseId !== undefined &&
+      (obj.leaseId = message.leaseId
+        ? LeaseID.toJSON(message.leaseId)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseLease>, I>>(
+    object: I,
+  ): MsgCloseLease {
+    const message = createBaseMsgCloseLease();
+    message.leaseId =
+      object.leaseId !== undefined && object.leaseId !== null
+        ? LeaseID.fromPartial(object.leaseId)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCloseLease.$type, MsgCloseLease);
+
+function createBaseMsgCloseLeaseResponse(): MsgCloseLeaseResponse {
+  return { $type: 'akash.market.v1beta1.MsgCloseLeaseResponse' };
+}
+
+export const MsgCloseLeaseResponse = {
+  $type: 'akash.market.v1beta1.MsgCloseLeaseResponse' as const,
+
+  encode(
+    _: MsgCloseLeaseResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgCloseLeaseResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCloseLeaseResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgCloseLeaseResponse {
+    return {
+      $type: MsgCloseLeaseResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgCloseLeaseResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCloseLeaseResponse>, I>>(
+    _: I,
+  ): MsgCloseLeaseResponse {
+    const message = createBaseMsgCloseLeaseResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCloseLeaseResponse.$type, MsgCloseLeaseResponse);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/akash/market/v1beta1/order.ts
+++ b/ts/src/deprecated/akash/market/v1beta1/order.ts
@@ -1,0 +1,428 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import { GroupSpec } from '../../../akash/deployment/v1beta1/group';
+
+export const protobufPackage = 'akash.market.v1beta1';
+
+/** OrderID stores owner and all other seq numbers */
+export interface OrderID {
+  $type: 'akash.market.v1beta1.OrderID';
+  owner: string;
+  dseq: Long;
+  gseq: number;
+  oseq: number;
+}
+
+/** Order stores orderID, state of order and other details */
+export interface Order {
+  $type: 'akash.market.v1beta1.Order';
+  orderId?: OrderID;
+  state: Order_State;
+  spec?: GroupSpec;
+  createdAt: Long;
+}
+
+/** State is an enum which refers to state of order */
+export enum Order_State {
+  /** invalid - Prefix should start with 0 in enum. So declaring dummy state */
+  invalid = 0,
+  /** open - OrderOpen denotes state for order open */
+  open = 1,
+  /** active - OrderMatched denotes state for order matched */
+  active = 2,
+  /** closed - OrderClosed denotes state for order lost */
+  closed = 3,
+  UNRECOGNIZED = -1,
+}
+
+export function order_StateFromJSON(object: any): Order_State {
+  switch (object) {
+    case 0:
+    case 'invalid':
+      return Order_State.invalid;
+    case 1:
+    case 'open':
+      return Order_State.open;
+    case 2:
+    case 'active':
+      return Order_State.active;
+    case 3:
+    case 'closed':
+      return Order_State.closed;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Order_State.UNRECOGNIZED;
+  }
+}
+
+export function order_StateToJSON(object: Order_State): string {
+  switch (object) {
+    case Order_State.invalid:
+      return 'invalid';
+    case Order_State.open:
+      return 'open';
+    case Order_State.active:
+      return 'active';
+    case Order_State.closed:
+      return 'closed';
+    default:
+      return 'UNKNOWN';
+  }
+}
+
+/** OrderFilters defines flags for order list filter */
+export interface OrderFilters {
+  $type: 'akash.market.v1beta1.OrderFilters';
+  owner: string;
+  dseq: Long;
+  gseq: number;
+  oseq: number;
+  state: string;
+}
+
+function createBaseOrderID(): OrderID {
+  return {
+    $type: 'akash.market.v1beta1.OrderID',
+    owner: '',
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+  };
+}
+
+export const OrderID = {
+  $type: 'akash.market.v1beta1.OrderID' as const,
+
+  encode(
+    message: OrderID,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.gseq !== 0) {
+      writer.uint32(24).uint32(message.gseq);
+    }
+    if (message.oseq !== 0) {
+      writer.uint32(32).uint32(message.oseq);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): OrderID {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseOrderID();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.gseq = reader.uint32();
+          break;
+        case 4:
+          message.oseq = reader.uint32();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): OrderID {
+    return {
+      $type: OrderID.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
+      gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
+      oseq: isSet(object.oseq) ? Number(object.oseq) : 0,
+    };
+  },
+
+  toJSON(message: OrderID): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.gseq !== undefined && (obj.gseq = Math.round(message.gseq));
+    message.oseq !== undefined && (obj.oseq = Math.round(message.oseq));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<OrderID>, I>>(object: I): OrderID {
+    const message = createBaseOrderID();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.gseq = object.gseq ?? 0;
+    message.oseq = object.oseq ?? 0;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(OrderID.$type, OrderID);
+
+function createBaseOrder(): Order {
+  return {
+    $type: 'akash.market.v1beta1.Order',
+    orderId: undefined,
+    state: 0,
+    spec: undefined,
+    createdAt: Long.ZERO,
+  };
+}
+
+export const Order = {
+  $type: 'akash.market.v1beta1.Order' as const,
+
+  encode(message: Order, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.orderId !== undefined) {
+      OrderID.encode(message.orderId, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.state !== 0) {
+      writer.uint32(16).int32(message.state);
+    }
+    if (message.spec !== undefined) {
+      GroupSpec.encode(message.spec, writer.uint32(26).fork()).ldelim();
+    }
+    if (!message.createdAt.isZero()) {
+      writer.uint32(32).int64(message.createdAt);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Order {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseOrder();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.orderId = OrderID.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.state = reader.int32() as any;
+          break;
+        case 3:
+          message.spec = GroupSpec.decode(reader, reader.uint32());
+          break;
+        case 4:
+          message.createdAt = reader.int64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Order {
+    return {
+      $type: Order.$type,
+      orderId: isSet(object.orderId)
+        ? OrderID.fromJSON(object.orderId)
+        : undefined,
+      state: isSet(object.state) ? order_StateFromJSON(object.state) : 0,
+      spec: isSet(object.spec) ? GroupSpec.fromJSON(object.spec) : undefined,
+      createdAt: isSet(object.createdAt)
+        ? Long.fromString(object.createdAt)
+        : Long.ZERO,
+    };
+  },
+
+  toJSON(message: Order): unknown {
+    const obj: any = {};
+    message.orderId !== undefined &&
+      (obj.orderId = message.orderId
+        ? OrderID.toJSON(message.orderId)
+        : undefined);
+    message.state !== undefined &&
+      (obj.state = order_StateToJSON(message.state));
+    message.spec !== undefined &&
+      (obj.spec = message.spec ? GroupSpec.toJSON(message.spec) : undefined);
+    message.createdAt !== undefined &&
+      (obj.createdAt = (message.createdAt || Long.ZERO).toString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Order>, I>>(object: I): Order {
+    const message = createBaseOrder();
+    message.orderId =
+      object.orderId !== undefined && object.orderId !== null
+        ? OrderID.fromPartial(object.orderId)
+        : undefined;
+    message.state = object.state ?? 0;
+    message.spec =
+      object.spec !== undefined && object.spec !== null
+        ? GroupSpec.fromPartial(object.spec)
+        : undefined;
+    message.createdAt =
+      object.createdAt !== undefined && object.createdAt !== null
+        ? Long.fromValue(object.createdAt)
+        : Long.ZERO;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Order.$type, Order);
+
+function createBaseOrderFilters(): OrderFilters {
+  return {
+    $type: 'akash.market.v1beta1.OrderFilters',
+    owner: '',
+    dseq: Long.UZERO,
+    gseq: 0,
+    oseq: 0,
+    state: '',
+  };
+}
+
+export const OrderFilters = {
+  $type: 'akash.market.v1beta1.OrderFilters' as const,
+
+  encode(
+    message: OrderFilters,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (!message.dseq.isZero()) {
+      writer.uint32(16).uint64(message.dseq);
+    }
+    if (message.gseq !== 0) {
+      writer.uint32(24).uint32(message.gseq);
+    }
+    if (message.oseq !== 0) {
+      writer.uint32(32).uint32(message.oseq);
+    }
+    if (message.state !== '') {
+      writer.uint32(42).string(message.state);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): OrderFilters {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseOrderFilters();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.dseq = reader.uint64() as Long;
+          break;
+        case 3:
+          message.gseq = reader.uint32();
+          break;
+        case 4:
+          message.oseq = reader.uint32();
+          break;
+        case 5:
+          message.state = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): OrderFilters {
+    return {
+      $type: OrderFilters.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      dseq: isSet(object.dseq) ? Long.fromString(object.dseq) : Long.UZERO,
+      gseq: isSet(object.gseq) ? Number(object.gseq) : 0,
+      oseq: isSet(object.oseq) ? Number(object.oseq) : 0,
+      state: isSet(object.state) ? String(object.state) : '',
+    };
+  },
+
+  toJSON(message: OrderFilters): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.dseq !== undefined &&
+      (obj.dseq = (message.dseq || Long.UZERO).toString());
+    message.gseq !== undefined && (obj.gseq = Math.round(message.gseq));
+    message.oseq !== undefined && (obj.oseq = Math.round(message.oseq));
+    message.state !== undefined && (obj.state = message.state);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<OrderFilters>, I>>(
+    object: I,
+  ): OrderFilters {
+    const message = createBaseOrderFilters();
+    message.owner = object.owner ?? '';
+    message.dseq =
+      object.dseq !== undefined && object.dseq !== null
+        ? Long.fromValue(object.dseq)
+        : Long.UZERO;
+    message.gseq = object.gseq ?? 0;
+    message.oseq = object.oseq ?? 0;
+    message.state = object.state ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(OrderFilters.$type, OrderFilters);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/cosmos/base/query/v1beta1/pagination.ts
+++ b/ts/src/deprecated/cosmos/base/query/v1beta1/pagination.ts
@@ -1,0 +1,338 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../../typeRegistry';
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'cosmos.base.query.v1beta1';
+
+/**
+ * PageRequest is to be embedded in gRPC request messages for efficient
+ * pagination. Ex:
+ *
+ *  message SomeRequest {
+ *          Foo some_parameter = 1;
+ *          PageRequest pagination = 2;
+ *  }
+ */
+export interface PageRequest {
+  $type: 'cosmos.base.query.v1beta1.PageRequest';
+  /**
+   * key is a value returned in PageResponse.next_key to begin
+   * querying the next page most efficiently. Only one of offset or key
+   * should be set.
+   */
+  key: Uint8Array;
+  /**
+   * offset is a numeric offset that can be used when key is unavailable.
+   * It is less efficient than using key. Only one of offset or key should
+   * be set.
+   */
+  offset: Long;
+  /**
+   * limit is the total number of results to be returned in the result page.
+   * If left empty it will default to a value to be set by each app.
+   */
+  limit: Long;
+  /**
+   * count_total is set to true  to indicate that the result set should include
+   * a count of the total number of items available for pagination in UIs.
+   * count_total is only respected when offset is used. It is ignored when key
+   * is set.
+   */
+  countTotal: boolean;
+  /**
+   * reverse is set to true if results are to be returned in the descending order.
+   *
+   * Since: cosmos-sdk 0.43
+   */
+  reverse: boolean;
+}
+
+/**
+ * PageResponse is to be embedded in gRPC response messages where the
+ * corresponding request message has used PageRequest.
+ *
+ *  message SomeResponse {
+ *          repeated Bar results = 1;
+ *          PageResponse page = 2;
+ *  }
+ */
+export interface PageResponse {
+  $type: 'cosmos.base.query.v1beta1.PageResponse';
+  /**
+   * next_key is the key to be passed to PageRequest.key to
+   * query the next page most efficiently
+   */
+  nextKey: Uint8Array;
+  /**
+   * total is total number of results available if PageRequest.count_total
+   * was set, its value is undefined otherwise
+   */
+  total: Long;
+}
+
+function createBasePageRequest(): PageRequest {
+  return {
+    $type: 'cosmos.base.query.v1beta1.PageRequest',
+    key: new Uint8Array(),
+    offset: Long.UZERO,
+    limit: Long.UZERO,
+    countTotal: false,
+    reverse: false,
+  };
+}
+
+export const PageRequest = {
+  $type: 'cosmos.base.query.v1beta1.PageRequest' as const,
+
+  encode(
+    message: PageRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    if (!message.offset.isZero()) {
+      writer.uint32(16).uint64(message.offset);
+    }
+    if (!message.limit.isZero()) {
+      writer.uint32(24).uint64(message.limit);
+    }
+    if (message.countTotal === true) {
+      writer.uint32(32).bool(message.countTotal);
+    }
+    if (message.reverse === true) {
+      writer.uint32(40).bool(message.reverse);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PageRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePageRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.bytes();
+          break;
+        case 2:
+          message.offset = reader.uint64() as Long;
+          break;
+        case 3:
+          message.limit = reader.uint64() as Long;
+          break;
+        case 4:
+          message.countTotal = reader.bool();
+          break;
+        case 5:
+          message.reverse = reader.bool();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PageRequest {
+    return {
+      $type: PageRequest.$type,
+      key: isSet(object.key) ? bytesFromBase64(object.key) : new Uint8Array(),
+      offset: isSet(object.offset) ? Long.fromValue(object.offset) : Long.UZERO,
+      limit: isSet(object.limit) ? Long.fromValue(object.limit) : Long.UZERO,
+      countTotal: isSet(object.countTotal) ? Boolean(object.countTotal) : false,
+      reverse: isSet(object.reverse) ? Boolean(object.reverse) : false,
+    };
+  },
+
+  toJSON(message: PageRequest): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(
+        message.key !== undefined ? message.key : new Uint8Array(),
+      ));
+    message.offset !== undefined &&
+      (obj.offset = (message.offset || Long.UZERO).toString());
+    message.limit !== undefined &&
+      (obj.limit = (message.limit || Long.UZERO).toString());
+    message.countTotal !== undefined && (obj.countTotal = message.countTotal);
+    message.reverse !== undefined && (obj.reverse = message.reverse);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PageRequest>, I>>(
+    object: I,
+  ): PageRequest {
+    const message = createBasePageRequest();
+    message.key = object.key ?? new Uint8Array();
+    message.offset =
+      object.offset !== undefined && object.offset !== null
+        ? Long.fromValue(object.offset)
+        : Long.UZERO;
+    message.limit =
+      object.limit !== undefined && object.limit !== null
+        ? Long.fromValue(object.limit)
+        : Long.UZERO;
+    message.countTotal = object.countTotal ?? false;
+    message.reverse = object.reverse ?? false;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(PageRequest.$type, PageRequest);
+
+function createBasePageResponse(): PageResponse {
+  return {
+    $type: 'cosmos.base.query.v1beta1.PageResponse',
+    nextKey: new Uint8Array(),
+    total: Long.UZERO,
+  };
+}
+
+export const PageResponse = {
+  $type: 'cosmos.base.query.v1beta1.PageResponse' as const,
+
+  encode(
+    message: PageResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.nextKey.length !== 0) {
+      writer.uint32(10).bytes(message.nextKey);
+    }
+    if (!message.total.isZero()) {
+      writer.uint32(16).uint64(message.total);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PageResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePageResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.nextKey = reader.bytes();
+          break;
+        case 2:
+          message.total = reader.uint64() as Long;
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PageResponse {
+    return {
+      $type: PageResponse.$type,
+      nextKey: isSet(object.nextKey)
+        ? bytesFromBase64(object.nextKey)
+        : new Uint8Array(),
+      total: isSet(object.total) ? Long.fromValue(object.total) : Long.UZERO,
+    };
+  },
+
+  toJSON(message: PageResponse): unknown {
+    const obj: any = {};
+    message.nextKey !== undefined &&
+      (obj.nextKey = base64FromBytes(
+        message.nextKey !== undefined ? message.nextKey : new Uint8Array(),
+      ));
+    message.total !== undefined &&
+      (obj.total = (message.total || Long.UZERO).toString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PageResponse>, I>>(
+    object: I,
+  ): PageResponse {
+    const message = createBasePageResponse();
+    message.nextKey = object.nextKey ?? new Uint8Array();
+    message.total =
+      object.total !== undefined && object.total !== null
+        ? Long.fromValue(object.total)
+        : Long.UZERO;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(PageResponse.$type, PageResponse);
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  arr.forEach((byte) => {
+    bin.push(String.fromCharCode(byte));
+  });
+  return btoa(bin.join(''));
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/cosmos/base/v1beta1/coin.ts
+++ b/ts/src/deprecated/cosmos/base/v1beta1/coin.ts
@@ -1,0 +1,325 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../typeRegistry';
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
+
+export const protobufPackage = 'cosmos.base.v1beta1';
+
+/**
+ * Coin defines a token with a denomination and an amount.
+ *
+ * NOTE: The amount field is an Int which implements the custom method
+ * signatures required by gogoproto.
+ */
+export interface Coin {
+  $type: 'cosmos.base.v1beta1.Coin';
+  denom: string;
+  amount: string;
+}
+
+/**
+ * DecCoin defines a token with a denomination and a decimal amount.
+ *
+ * NOTE: The amount field is an Dec which implements the custom method
+ * signatures required by gogoproto.
+ */
+export interface DecCoin {
+  $type: 'cosmos.base.v1beta1.DecCoin';
+  denom: string;
+  amount: string;
+}
+
+/** IntProto defines a Protobuf wrapper around an Int object. */
+export interface IntProto {
+  $type: 'cosmos.base.v1beta1.IntProto';
+  int: string;
+}
+
+/** DecProto defines a Protobuf wrapper around a Dec object. */
+export interface DecProto {
+  $type: 'cosmos.base.v1beta1.DecProto';
+  dec: string;
+}
+
+function createBaseCoin(): Coin {
+  return { $type: 'cosmos.base.v1beta1.Coin', denom: '', amount: '' };
+}
+
+export const Coin = {
+  $type: 'cosmos.base.v1beta1.Coin' as const,
+
+  encode(message: Coin, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Coin {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCoin();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.denom = reader.string();
+          break;
+        case 2:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Coin {
+    return {
+      $type: Coin.$type,
+      denom: isSet(object.denom) ? String(object.denom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+
+  toJSON(message: Coin): unknown {
+    const obj: any = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Coin>, I>>(object: I): Coin {
+    const message = createBaseCoin();
+    message.denom = object.denom ?? '';
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Coin.$type, Coin);
+
+function createBaseDecCoin(): DecCoin {
+  return { $type: 'cosmos.base.v1beta1.DecCoin', denom: '', amount: '' };
+}
+
+export const DecCoin = {
+  $type: 'cosmos.base.v1beta1.DecCoin' as const,
+
+  encode(
+    message: DecCoin,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.denom !== '') {
+      writer.uint32(10).string(message.denom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount.padEnd(23, '0'));
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DecCoin {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDecCoin();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.denom = reader.string();
+          break;
+        case 2:
+          message.amount = (parseInt(reader.string()) / 10 ** 18).toPrecision(
+            18,
+          );
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DecCoin {
+    return {
+      $type: DecCoin.$type,
+      denom: isSet(object.denom) ? String(object.denom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+
+  toJSON(message: DecCoin): unknown {
+    const obj: any = {};
+    message.denom !== undefined && (obj.denom = message.denom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DecCoin>, I>>(object: I): DecCoin {
+    const message = createBaseDecCoin();
+    message.denom = object.denom ?? '';
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(DecCoin.$type, DecCoin);
+
+function createBaseIntProto(): IntProto {
+  return { $type: 'cosmos.base.v1beta1.IntProto', int: '' };
+}
+
+export const IntProto = {
+  $type: 'cosmos.base.v1beta1.IntProto' as const,
+
+  encode(
+    message: IntProto,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.int !== '') {
+      writer.uint32(10).string(message.int);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): IntProto {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseIntProto();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.int = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): IntProto {
+    return {
+      $type: IntProto.$type,
+      int: isSet(object.int) ? String(object.int) : '',
+    };
+  },
+
+  toJSON(message: IntProto): unknown {
+    const obj: any = {};
+    message.int !== undefined && (obj.int = message.int);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<IntProto>, I>>(object: I): IntProto {
+    const message = createBaseIntProto();
+    message.int = object.int ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(IntProto.$type, IntProto);
+
+function createBaseDecProto(): DecProto {
+  return { $type: 'cosmos.base.v1beta1.DecProto', dec: '' };
+}
+
+export const DecProto = {
+  $type: 'cosmos.base.v1beta1.DecProto' as const,
+
+  encode(
+    message: DecProto,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.dec !== '') {
+      writer.uint32(10).string(message.dec);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DecProto {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDecProto();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.dec = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DecProto {
+    return {
+      $type: DecProto.$type,
+      dec: isSet(object.dec) ? String(object.dec) : '',
+    };
+  },
+
+  toJSON(message: DecProto): unknown {
+    const obj: any = {};
+    message.dec !== undefined && (obj.dec = message.dec);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DecProto>, I>>(object: I): DecProto {
+    const message = createBaseDecProto();
+    message.dec = object.dec ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(DecProto.$type, DecProto);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/ts/src/deprecated/index.akash.cert.v1beta1.ts
+++ b/ts/src/deprecated/index.akash.cert.v1beta1.ts
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+export * from './akash/cert/v1beta1/cert';

--- a/ts/src/deprecated/index.akash.market.v1beta1.ts
+++ b/ts/src/deprecated/index.akash.market.v1beta1.ts
@@ -1,0 +1,4 @@
+/* eslint-disable */
+
+export * from './akash/market/v1beta1/bid';
+export * from './akash/market/v1beta1/lease';

--- a/ts/src/deprecated/typeRegistry.ts
+++ b/ts/src/deprecated/typeRegistry.ts
@@ -1,0 +1,36 @@
+/* eslint-disable */
+import * as _m0 from 'protobufjs/minimal';
+import Long from 'long';
+
+export interface MessageType<Message extends UnknownMessage = UnknownMessage> {
+  $type: Message['$type'];
+  encode(message: Message, writer?: _m0.Writer): _m0.Writer;
+  decode(input: _m0.Reader | Uint8Array, length?: number): Message;
+  fromJSON(object: any): Message;
+  toJSON(message: Message): unknown;
+  fromPartial(object: DeepPartial<Message>): Message;
+}
+
+export type UnknownMessage = { $type: string };
+
+export const messageTypeRegistry = new Map<string, MessageType>();
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+    ? string | number | Long
+    : T extends Array<infer U>
+      ? Array<DeepPartial<U>>
+      : T extends ReadonlyArray<infer U>
+        ? ReadonlyArray<DeepPartial<U>>
+        : T extends {}
+          ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+          : Partial<T>;

--- a/ts/src/patch/cosmos/base/v1beta1/coin.ts
+++ b/ts/src/patch/cosmos/base/v1beta1/coin.ts
@@ -1,5 +1,5 @@
-import { Reader } from 'protobufjs/minimal';
 import * as minimal from 'protobufjs/minimal';
+import { Reader } from 'protobufjs/minimal';
 
 import * as coin from '../../../../generated/cosmos/base/v1beta1/coin.original';
 import { DecCoin } from '../../../../generated/cosmos/base/v1beta1/coin.original';

--- a/ts/static-exports.json
+++ b/ts/static-exports.json
@@ -1,0 +1,21 @@
+{
+  "package": {
+    "./": "./dist/index.js",
+    "./typeRegistry": "./dist/generated/typeRegistry.js",
+    "./akash/deployment/v1beta3/query": "./dist/generated/akash/deployment/v1beta3/query.js",
+    "./deprecated/akash/cert/v1beta1": "./dist/deprecated/index.akash.cert.v1beta1.js",
+    "./deprecated/akash/market/v1beta1": "./dist/deprecated/index.akash.market.v1beta1.js"
+  },
+  "tsconfig": {
+    "@akashnetwork/akash-api/typeRegistry": ["./dist/generated/typeRegistry"],
+    "@akashnetwork/akash-api/akash/deployment/v1beta3/query": [
+      "./dist/generated/akash/deployment/v1beta3/query"
+    ],
+    "@akashnetwork/akash-api/deprecated/akash/cert/v1beta1": [
+      "./dist/deprecated/index.akash.cert.v1beta1"
+    ],
+    "@akashnetwork/akash-api/deprecated/akash/market/v1beta1": [
+      "./dist/deprecated/index.akash.market.v1beta1"
+    ]
+  }
+}


### PR DESCRIPTION
This pull request addresses the continued reliance of Cloudmos on the `market` and `cert` `v1beta1` modules, which are considered legacy. To streamline the management of deprecated code and ensure accessibility, we are moving these modules to a `deprecated` directory within the `akash-api`.

### Key Changes
1. **Relocation of Modules**: The `market` and `cert` `v1beta1` modules have been moved to a new `deprecated` path within the `akash-api`. This move consolidates all generated code, even that which is slated for deprecation, ensuring it remains accessible and maintainable.

2. **Preparation for Future Deprecations**: Establishing a `deprecated` directory sets a precedent for handling future deprecations. It provides a structured approach to maintain older code that might still be necessary for backward compatibility or transitional purposes.

### Usage example
```typescript
export { MsgCreateCertificate, MsgRevokeCertificate } from "@akashnetwork/akash-api/deprecated/akash/cert/v1beta1";
export { MsgCreateBid, MsgCloseBid, MsgCreateLease, MsgWithdrawLease, MsgCloseLease } from "@akashnetwork/akash-api/deprecated/akash/market/v1beta1";
```

**Note**: `src/deprecated` dir is entirely a copy/paste from `akashjs`
