### PR TITLE
feat(ts): add essential exports by versions (#184)

### DIFF
--- a/ts/jest.config.js
+++ b/ts/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     '!<rootDir>/src/generated/**/*',
     '!<rootDir>/src/deprecated/**/*',
     '!<rootDir>/src/patch/index.*',
+    '!<rootDir>/src/index.*',
   ],
   projects: [
     {

--- a/ts/src/index.v1beta1.ts
+++ b/ts/src/index.v1beta1.ts
@@ -1,0 +1,29 @@
+export {
+  MsgSignProviderAttributes,
+  MsgDeleteProviderAttributes,
+} from './generated/index.akash.audit.v1beta1';
+export {
+  MsgCloseGroup,
+  MsgPauseGroup,
+  MsgStartGroup,
+  MsgCreateDeployment,
+  MsgDepositDeployment,
+  MsgUpdateDeployment,
+  MsgCloseDeployment,
+} from './generated/index.akash.deployment.v1beta1';
+export {
+  MsgCreateProvider,
+  MsgUpdateProvider,
+  MsgDeleteProvider,
+} from './generated/index.akash.provider.v1beta1';
+export {
+  MsgCreateCertificate,
+  MsgRevokeCertificate,
+} from './deprecated/index.akash.cert.v1beta1';
+export {
+  MsgCreateBid,
+  MsgCloseBid,
+  MsgCreateLease,
+  MsgWithdrawLease,
+  MsgCloseLease,
+} from './deprecated/index.akash.market.v1beta1';

--- a/ts/src/index.v1beta2.ts
+++ b/ts/src/index.v1beta2.ts
@@ -1,0 +1,32 @@
+export {
+  MsgSignProviderAttributes,
+  MsgDeleteProviderAttributes,
+} from './generated/index.akash.audit.v1beta2';
+export {
+  MsgCreateCertificate,
+  MsgRevokeCertificate,
+} from './generated/index.akash.cert.v1beta2';
+export {
+  MsgCloseGroup,
+  MsgPauseGroup,
+  MsgStartGroup,
+  MsgCreateDeployment,
+  MsgDepositDeployment,
+  MsgUpdateDeployment,
+  MsgCloseDeployment,
+} from './patch/index.akash.deployment.v1beta2';
+export {
+  MsgCreateBid,
+  MsgCloseBid,
+} from './generated/index.akash.market.v1beta2';
+export {
+  MsgCreateLease,
+  MsgWithdrawLease,
+  MsgCloseLease,
+} from './generated/index.akash.market.v1beta2';
+export {
+  MsgCreateProvider,
+  MsgUpdateProvider,
+  MsgDeleteProvider,
+} from './generated/index.akash.provider.v1beta2';
+export { Storage } from './generated/index.akash.base.v1beta2';

--- a/ts/src/index.v1beta3.ts
+++ b/ts/src/index.v1beta3.ts
@@ -1,0 +1,33 @@
+export {
+  MsgSignProviderAttributes,
+  MsgDeleteProviderAttributes,
+} from './generated/index.akash.audit.v1beta3';
+export {
+  MsgCreateCertificate,
+  MsgRevokeCertificate,
+} from './generated/index.akash.cert.v1beta3';
+export {
+  MsgCloseGroup,
+  MsgPauseGroup,
+  MsgStartGroup,
+  DepositDeploymentAuthorization,
+  MsgCreateDeployment,
+  MsgDepositDeployment,
+  MsgUpdateDeployment,
+  MsgCloseDeployment,
+} from './patch/index.akash.deployment.v1beta3';
+export {
+  MsgCreateBid,
+  MsgCloseBid,
+} from './generated/index.akash.market.v1beta3';
+export {
+  MsgCreateLease,
+  MsgWithdrawLease,
+  MsgCloseLease,
+} from './generated/index.akash.market.v1beta3';
+export {
+  MsgCreateProvider,
+  MsgUpdateProvider,
+  MsgDeleteProvider,
+} from './generated/index.akash.provider.v1beta3';
+export { Storage, GPU } from './patch/index.akash.base.v1beta3';

--- a/ts/src/index.v1beta4.ts
+++ b/ts/src/index.v1beta4.ts
@@ -1,0 +1,7 @@
+export {
+  MsgCreateBid,
+  MsgCloseBid,
+  MsgCreateLease,
+  MsgWithdrawLease,
+  MsgCloseLease,
+} from './generated/index.akash.market.v1beta4';

--- a/ts/static-exports.json
+++ b/ts/static-exports.json
@@ -4,7 +4,11 @@
     "./typeRegistry": "./dist/generated/typeRegistry.js",
     "./akash/deployment/v1beta3/query": "./dist/generated/akash/deployment/v1beta3/query.js",
     "./deprecated/akash/cert/v1beta1": "./dist/deprecated/index.akash.cert.v1beta1.js",
-    "./deprecated/akash/market/v1beta1": "./dist/deprecated/index.akash.market.v1beta1.js"
+    "./deprecated/akash/market/v1beta1": "./dist/deprecated/index.akash.market.v1beta1.js",
+    "./v1beta1": "./dist/index.v1beta1.js",
+    "./v1beta2": "./dist/index.v1beta2.js",
+    "./v1beta3": "./dist/index.v1beta3.js",
+    "./v1beta4": "./dist/index.v1beta4.js"
   },
   "tsconfig": {
     "@akashnetwork/akash-api/typeRegistry": ["./dist/generated/typeRegistry"],
@@ -16,6 +20,10 @@
     ],
     "@akashnetwork/akash-api/deprecated/akash/market/v1beta1": [
       "./dist/deprecated/index.akash.market.v1beta1"
-    ]
+    ],
+    "@akashnetwork/akash-api/v1beta1": ["./dist/index.v1beta1"],
+    "@akashnetwork/akash-api/v1beta2": ["./dist/index.v1beta2"],
+    "@akashnetwork/akash-api/v1beta3": ["./dist/index.v1beta3"],
+    "@akashnetwork/akash-api/v1beta4": ["./dist/index.v1beta4"]
   }
 }


### PR DESCRIPTION
This pull request introduces a more streamlined approach to managing and exporting Akash protobuf files across various projects. By centralizing exports, I aim to reduce code duplication and improve maintainability across the ecosystem.

### Key Changes
1. **Centralized Exports**: Added necessary exports organized by groups and versions in the `akash-api` repository. This change allows other projects (like Cloudmos API, Indexer, and Deploy-Web) to utilize a single source of truth instead of maintaining duplicated code across different repositories.

### Current Differences and Impact
I've identified slight variations in the proto files used across different projects:
- **Indexer v1beta2**: Includes a unique `Storage` import.
- **Indexer v1beta3**: Contains a `GPU` import not present in other versions.
- **Web v1beta3**: Features a `DepositDeploymentAuthorization` import.

### Question for Review
Is the presence of these unique imports intended, or should the proto files be uniform across all versions and projects? Understanding this will guide whether I can safely replace the duplicated files with centralized exports from the `akash-api`.

### Proposal
Assuming these differences are not required for specific functional needs, my proposal is to eliminate all duplicate proto files in favor of those exported from the `akash-api`. This would simplify the codebase and ensure consistency.