### PR TITLE
fix(client/v1beta2): handle sequence mismatch during calculate gas

### DIFF
--- a/go/node/client/client.go
+++ b/go/node/client/client.go
@@ -16,8 +16,8 @@ var (
 )
 
 const (
-	// DefaultClientApiVersion indicates the default ApiVersion of the client.
-	DefaultClientApiVersion = "v1beta2"
+	// DefaultClientAPIVersion indicates the default ApiVersion of the client.
+	DefaultClientAPIVersion = "v1beta2"
 )
 
 // SetupFn defines a function that takes a parameter, ideally a Client or QueryClient.
@@ -27,7 +27,7 @@ type SetupFn func(interface{}) error
 // DiscoverClient queries an RPC node to get the version of the client and executes a SetupFn function
 // passing a new versioned Client instance as parameter.
 // If any error occurs when calling the RPC node or the Cosmos SDK client Context is set to offline the default value of
-// DefaultClientApiVersion will be used.
+// DefaultClientAPIVersion will be used.
 // An error is returned if client discovery is not successful.
 func DiscoverClient(ctx context.Context, cctx sdkclient.Context, setup SetupFn, opts ...cltypes.ClientOption) error {
 	rpc, err := tmjclient.New(cctx.NodeURI)
@@ -43,9 +43,9 @@ func DiscoverClient(ctx context.Context, cctx sdkclient.Context, setup SetupFn, 
 	}
 
 	// if client info is nil, mostly likely "akash" endpoint is not yet supported on the node
-	// fallback to manually set version to DefaultClientApiVersion
+	// fallback to manually set version to DefaultClientAPIVersion
 	if result.ClientInfo == nil || cctx.Offline {
-		result.ClientInfo = &ClientInfo{ApiVersion: DefaultClientApiVersion}
+		result.ClientInfo = &ClientInfo{ApiVersion: DefaultClientAPIVersion}
 	}
 
 	var cl interface{}
@@ -71,7 +71,7 @@ func DiscoverClient(ctx context.Context, cctx sdkclient.Context, setup SetupFn, 
 // DiscoverQueryClient queries an RPC node to get the version of the client and executes a SetupFn function
 // passing a new versioned QueryClient instance as parameter.
 // If any error occurs when calling the RPC node or the Cosmos SDK client Context is set to offline the default value of
-// DefaultClientApiVersion will be used.
+// DefaultClientAPIVersion will be used.
 // An error is returned if client discovery is not successful.
 func DiscoverQueryClient(ctx context.Context, cctx sdkclient.Context, setup SetupFn) error {
 	rpc, err := tmjclient.New(cctx.NodeURI)
@@ -87,7 +87,7 @@ func DiscoverQueryClient(ctx context.Context, cctx sdkclient.Context, setup Setu
 	}
 
 	if result.ClientInfo == nil {
-		result.ClientInfo = &ClientInfo{ApiVersion: DefaultClientApiVersion}
+		result.ClientInfo = &ClientInfo{ApiVersion: DefaultClientAPIVersion}
 	}
 
 	var cl interface{}


### PR DESCRIPTION
due to cosmos-sdk not returning ABCI errors for /simulate call exact error match does not work and we have to rely and strings compare

fixes akash-network/support#13