### PR TITLE
chore: changes symlink to k8s.io with hard link copies

### DIFF
--- a/make/mod.mk
+++ b/make/mod.mk
@@ -36,7 +36,7 @@ modvendor: $(MODVENDOR) $(PROTOC) modsensure
 	$(MODVENDOR) -copy="**/*.proto" -include=github.com/cosmos/cosmos-proto/proto
 	$(MODVENDOR) -copy="**/swagger.yaml" -include=github.com/cosmos/cosmos-proto/client/docs/swagger-ui
 	$(MODVENDOR) -copy="**/*.proto" -include=k8s.io/apimachinery
-	@ln -snf ../../vendor/k8s.io .cache/include/k8s.io
+	@cp -Rl vendor/k8s.io .cache/include/k8s.io
 	@echo "$${VENDOR_BUF}" > vendor/k8s.io/buf.yaml
 	@echo "$${VENDOR_BUF}" > .cache/include/google/buf.yaml
 	@echo "$${VENDOR_BUF}" > vendor/github.com/cosmos/cosmos-sdk/proto/buf.yaml


### PR DESCRIPTION
## Why

I'm using [telescope](https://github.com/hyperweb-io/telescope) to generate typescript types and client and it doesn't follow symlinks

## What

changes symlink to k8s.io with hard link copies