### PR TITLE
feat: adds support for provider sdk

### DIFF
--- a/ts/esbuild.config.mjs
+++ b/ts/esbuild.config.mjs
@@ -1,0 +1,35 @@
+import * as esbuild from 'esbuild';
+import packageDetails from './package.json' with { type: 'json' };
+
+/**
+ * @type {esbuild.BuildOptions}
+ * @param {esbuild.BuildOptions} config
+ */
+const baseConfig = (config) => ({
+  ...config,
+  entryPoints: [
+    'src/sdk/nodejs/createProviderSDK.ts',
+  ],
+  bundle: true,
+  sourcemap: true,
+  external: Object.keys(packageDetails.dependencies),
+});
+
+/**
+ * @type {esbuild.BuildOptions}
+ * @param {esbuild.BuildOptions['format']} format
+ */
+const nodeJsConfig = (format) => baseConfig({
+  minify: false,
+  target: [`node${packageDetails.engines.node}`],
+  format,
+  splitting: format === 'esm',
+  platform: 'node',
+  outdir: `dist/nodejs/${format}`,
+});
+
+await Promise.all([
+  esbuild.build(nodeJsConfig('esm')),
+  esbuild.build(nodeJsConfig('cjs')),
+]);
+console.log('Building Nodejs SDK finished');

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -17,6 +17,7 @@
         "@faker-js/faker": "^9.7.0",
         "@jest/globals": "^29.7.0",
         "@stylistic/eslint-plugin": "^4.0.1",
+        "esbuild": "^0.25.2",
         "eslint": "^9.24.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -676,6 +677,431 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "version": "0.8.1"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/android-arm": {
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/android-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
+      "version": "0.25.2"
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
+      "version": "0.25.2"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "dependencies": {
@@ -3270,6 +3696,47 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
       "version": "1.3.0"
+    },
+    "node_modules/esbuild": {
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "hasInstallScript": true,
+      "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.2",
+        "@esbuild/android-arm": "0.25.2",
+        "@esbuild/android-arm64": "0.25.2",
+        "@esbuild/android-x64": "0.25.2",
+        "@esbuild/darwin-arm64": "0.25.2",
+        "@esbuild/darwin-x64": "0.25.2",
+        "@esbuild/freebsd-arm64": "0.25.2",
+        "@esbuild/freebsd-x64": "0.25.2",
+        "@esbuild/linux-arm": "0.25.2",
+        "@esbuild/linux-arm64": "0.25.2",
+        "@esbuild/linux-ia32": "0.25.2",
+        "@esbuild/linux-loong64": "0.25.2",
+        "@esbuild/linux-mips64el": "0.25.2",
+        "@esbuild/linux-ppc64": "0.25.2",
+        "@esbuild/linux-riscv64": "0.25.2",
+        "@esbuild/linux-s390x": "0.25.2",
+        "@esbuild/linux-x64": "0.25.2",
+        "@esbuild/netbsd-arm64": "0.25.2",
+        "@esbuild/netbsd-x64": "0.25.2",
+        "@esbuild/openbsd-arm64": "0.25.2",
+        "@esbuild/openbsd-x64": "0.25.2",
+        "@esbuild/sunos-x64": "0.25.2",
+        "@esbuild/win32-arm64": "0.25.2",
+        "@esbuild/win32-ia32": "0.25.2",
+        "@esbuild/win32-x64": "0.25.2"
+      },
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
+      "version": "0.25.2"
     },
     "node_modules/escalade": {
       "dev": true,

--- a/ts/package.json
+++ b/ts/package.json
@@ -11,13 +11,21 @@
   "license": "Apache-2.0",
   "author": "Akash Network Team",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    "./protos/*": {
+      "types": "./dist/types/generated/protos/*"
+    },
+    "./provider": {
+      "import": "./dist/nodejs/esm/createProviderSDK.js",
+      "require": "./dist/nodejs/cjs/createProviderSDK.js",
+      "types": "./dist/types/sdk/nodejs/createProviderSDK.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist && tsc -p tsconfig.build.json && node esbuild.config.mjs",
     "lint": "eslint src",
     "lint:fix": "npm run lint -- --fix",
     "prepare": "cd .. && husky ts/.husky",
@@ -51,6 +59,7 @@
     "@faker-js/faker": "^9.7.0",
     "@jest/globals": "^29.7.0",
     "@stylistic/eslint-plugin": "^4.0.1",
+    "esbuild": "^0.25.2",
     "eslint": "^9.24.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -64,6 +73,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.29.1"
+  },
+  "engines": {
+    "node": "22.14.0"
   },
   "volta": {
     "node": "22.14.0"

--- a/ts/script/protoc-gen-sdk-object.ts
+++ b/ts/script/protoc-gen-sdk-object.ts
@@ -77,7 +77,7 @@ function generateTs(schema: Schema): void {
     }
   });
 
-  Array.from(imports).forEach((importPath) => {
+  imports.forEach((importPath) => {
     f.print(`import type * as ${fileNameToScope(importPath)} from "${importPath.startsWith("./") ? "./" + normalizePath(`${PROTO_PATH}/${importPath}${importExtension}`) : importPath}";`);
   });
   f.print(`import { createClientFactory } from "../client/createClientFactory${importExtension}";`);
@@ -179,7 +179,10 @@ function stringifyObject(obj: Record<string, any>, tabSize = 0, wrap = (value: s
 }
 
 function fileNameToScope(fileName: string) {
-  return normalizePath(fileName).replace(/\W+/g, "_").replace(/^_+/, "");
+  return normalizePath(fileName).replace(/\W+/g, "_")
+    .replace(/^_+/, "")
+    .replace(/^protos_/, "")
+    .replace(/_pb$/, "");
 }
 
 function jsDoc(method: DescMethod, methodName: string) {

--- a/ts/src/generated/createCosmosSDK.ts
+++ b/ts/src/generated/createCosmosSDK.ts
@@ -1,46 +1,46 @@
-import type * as cosmos_app_v1alpha1_query_pb from "./protos/cosmos/app/v1alpha1/query_pb.ts";
-import type * as cosmos_auth_v1beta1_query_pb from "./protos/cosmos/auth/v1beta1/query_pb.ts";
-import type * as cosmos_auth_v1beta1_tx_pb from "./protos/cosmos/auth/v1beta1/tx_pb.ts";
-import type * as cosmos_authz_v1beta1_query_pb from "./protos/cosmos/authz/v1beta1/query_pb.ts";
-import type * as cosmos_authz_v1beta1_tx_pb from "./protos/cosmos/authz/v1beta1/tx_pb.ts";
-import type * as cosmos_autocli_v1_query_pb from "./protos/cosmos/autocli/v1/query_pb.ts";
-import type * as cosmos_bank_v1beta1_query_pb from "./protos/cosmos/bank/v1beta1/query_pb.ts";
-import type * as cosmos_bank_v1beta1_tx_pb from "./protos/cosmos/bank/v1beta1/tx_pb.ts";
-import type * as tendermint_abci_types_pb from "./protos/tendermint/abci/types_pb.ts";
-import type * as cosmos_base_node_v1beta1_query_pb from "./protos/cosmos/base/node/v1beta1/query_pb.ts";
-import type * as cosmos_base_reflection_v1beta1_reflection_pb from "./protos/cosmos/base/reflection/v1beta1/reflection_pb.ts";
-import type * as cosmos_base_reflection_v2alpha1_reflection_pb from "./protos/cosmos/base/reflection/v2alpha1/reflection_pb.ts";
-import type * as cosmos_base_tendermint_v1beta1_query_pb from "./protos/cosmos/base/tendermint/v1beta1/query_pb.ts";
-import type * as cosmos_consensus_v1_query_pb from "./protos/cosmos/consensus/v1/query_pb.ts";
-import type * as cosmos_consensus_v1_tx_pb from "./protos/cosmos/consensus/v1/tx_pb.ts";
-import type * as cosmos_crisis_v1beta1_tx_pb from "./protos/cosmos/crisis/v1beta1/tx_pb.ts";
-import type * as cosmos_distribution_v1beta1_query_pb from "./protos/cosmos/distribution/v1beta1/query_pb.ts";
-import type * as cosmos_distribution_v1beta1_tx_pb from "./protos/cosmos/distribution/v1beta1/tx_pb.ts";
-import type * as cosmos_evidence_v1beta1_query_pb from "./protos/cosmos/evidence/v1beta1/query_pb.ts";
-import type * as cosmos_evidence_v1beta1_tx_pb from "./protos/cosmos/evidence/v1beta1/tx_pb.ts";
-import type * as cosmos_feegrant_v1beta1_query_pb from "./protos/cosmos/feegrant/v1beta1/query_pb.ts";
-import type * as cosmos_feegrant_v1beta1_tx_pb from "./protos/cosmos/feegrant/v1beta1/tx_pb.ts";
-import type * as cosmos_gov_v1_query_pb from "./protos/cosmos/gov/v1/query_pb.ts";
-import type * as cosmos_gov_v1_tx_pb from "./protos/cosmos/gov/v1/tx_pb.ts";
-import type * as cosmos_gov_v1beta1_query_pb from "./protos/cosmos/gov/v1beta1/query_pb.ts";
-import type * as cosmos_gov_v1beta1_tx_pb from "./protos/cosmos/gov/v1beta1/tx_pb.ts";
-import type * as cosmos_group_v1_query_pb from "./protos/cosmos/group/v1/query_pb.ts";
-import type * as cosmos_group_v1_tx_pb from "./protos/cosmos/group/v1/tx_pb.ts";
-import type * as cosmos_mint_v1beta1_query_pb from "./protos/cosmos/mint/v1beta1/query_pb.ts";
-import type * as cosmos_mint_v1beta1_tx_pb from "./protos/cosmos/mint/v1beta1/tx_pb.ts";
-import type * as cosmos_nft_v1beta1_query_pb from "./protos/cosmos/nft/v1beta1/query_pb.ts";
-import type * as cosmos_nft_v1beta1_tx_pb from "./protos/cosmos/nft/v1beta1/tx_pb.ts";
-import type * as cosmos_orm_query_v1alpha1_query_pb from "./protos/cosmos/orm/query/v1alpha1/query_pb.ts";
-import type * as cosmos_params_v1beta1_query_pb from "./protos/cosmos/params/v1beta1/query_pb.ts";
-import type * as cosmos_reflection_v1_reflection_pb from "./protos/cosmos/reflection/v1/reflection_pb.ts";
-import type * as cosmos_slashing_v1beta1_query_pb from "./protos/cosmos/slashing/v1beta1/query_pb.ts";
-import type * as cosmos_slashing_v1beta1_tx_pb from "./protos/cosmos/slashing/v1beta1/tx_pb.ts";
-import type * as cosmos_staking_v1beta1_query_pb from "./protos/cosmos/staking/v1beta1/query_pb.ts";
-import type * as cosmos_staking_v1beta1_tx_pb from "./protos/cosmos/staking/v1beta1/tx_pb.ts";
-import type * as cosmos_tx_v1beta1_service_pb from "./protos/cosmos/tx/v1beta1/service_pb.ts";
-import type * as cosmos_upgrade_v1beta1_query_pb from "./protos/cosmos/upgrade/v1beta1/query_pb.ts";
-import type * as cosmos_upgrade_v1beta1_tx_pb from "./protos/cosmos/upgrade/v1beta1/tx_pb.ts";
-import type * as cosmos_vesting_v1beta1_tx_pb from "./protos/cosmos/vesting/v1beta1/tx_pb.ts";
+import type * as cosmos_app_v1alpha1_query from "./protos/cosmos/app/v1alpha1/query_pb.ts";
+import type * as cosmos_auth_v1beta1_query from "./protos/cosmos/auth/v1beta1/query_pb.ts";
+import type * as cosmos_auth_v1beta1_tx from "./protos/cosmos/auth/v1beta1/tx_pb.ts";
+import type * as cosmos_authz_v1beta1_query from "./protos/cosmos/authz/v1beta1/query_pb.ts";
+import type * as cosmos_authz_v1beta1_tx from "./protos/cosmos/authz/v1beta1/tx_pb.ts";
+import type * as cosmos_autocli_v1_query from "./protos/cosmos/autocli/v1/query_pb.ts";
+import type * as cosmos_bank_v1beta1_query from "./protos/cosmos/bank/v1beta1/query_pb.ts";
+import type * as cosmos_bank_v1beta1_tx from "./protos/cosmos/bank/v1beta1/tx_pb.ts";
+import type * as tendermint_abci_types from "./protos/tendermint/abci/types_pb.ts";
+import type * as cosmos_base_node_v1beta1_query from "./protos/cosmos/base/node/v1beta1/query_pb.ts";
+import type * as cosmos_base_reflection_v1beta1_reflection from "./protos/cosmos/base/reflection/v1beta1/reflection_pb.ts";
+import type * as cosmos_base_reflection_v2alpha1_reflection from "./protos/cosmos/base/reflection/v2alpha1/reflection_pb.ts";
+import type * as cosmos_base_tendermint_v1beta1_query from "./protos/cosmos/base/tendermint/v1beta1/query_pb.ts";
+import type * as cosmos_consensus_v1_query from "./protos/cosmos/consensus/v1/query_pb.ts";
+import type * as cosmos_consensus_v1_tx from "./protos/cosmos/consensus/v1/tx_pb.ts";
+import type * as cosmos_crisis_v1beta1_tx from "./protos/cosmos/crisis/v1beta1/tx_pb.ts";
+import type * as cosmos_distribution_v1beta1_query from "./protos/cosmos/distribution/v1beta1/query_pb.ts";
+import type * as cosmos_distribution_v1beta1_tx from "./protos/cosmos/distribution/v1beta1/tx_pb.ts";
+import type * as cosmos_evidence_v1beta1_query from "./protos/cosmos/evidence/v1beta1/query_pb.ts";
+import type * as cosmos_evidence_v1beta1_tx from "./protos/cosmos/evidence/v1beta1/tx_pb.ts";
+import type * as cosmos_feegrant_v1beta1_query from "./protos/cosmos/feegrant/v1beta1/query_pb.ts";
+import type * as cosmos_feegrant_v1beta1_tx from "./protos/cosmos/feegrant/v1beta1/tx_pb.ts";
+import type * as cosmos_gov_v1_query from "./protos/cosmos/gov/v1/query_pb.ts";
+import type * as cosmos_gov_v1_tx from "./protos/cosmos/gov/v1/tx_pb.ts";
+import type * as cosmos_gov_v1beta1_query from "./protos/cosmos/gov/v1beta1/query_pb.ts";
+import type * as cosmos_gov_v1beta1_tx from "./protos/cosmos/gov/v1beta1/tx_pb.ts";
+import type * as cosmos_group_v1_query from "./protos/cosmos/group/v1/query_pb.ts";
+import type * as cosmos_group_v1_tx from "./protos/cosmos/group/v1/tx_pb.ts";
+import type * as cosmos_mint_v1beta1_query from "./protos/cosmos/mint/v1beta1/query_pb.ts";
+import type * as cosmos_mint_v1beta1_tx from "./protos/cosmos/mint/v1beta1/tx_pb.ts";
+import type * as cosmos_nft_v1beta1_query from "./protos/cosmos/nft/v1beta1/query_pb.ts";
+import type * as cosmos_nft_v1beta1_tx from "./protos/cosmos/nft/v1beta1/tx_pb.ts";
+import type * as cosmos_orm_query_v1alpha1_query from "./protos/cosmos/orm/query/v1alpha1/query_pb.ts";
+import type * as cosmos_params_v1beta1_query from "./protos/cosmos/params/v1beta1/query_pb.ts";
+import type * as cosmos_reflection_v1_reflection from "./protos/cosmos/reflection/v1/reflection_pb.ts";
+import type * as cosmos_slashing_v1beta1_query from "./protos/cosmos/slashing/v1beta1/query_pb.ts";
+import type * as cosmos_slashing_v1beta1_tx from "./protos/cosmos/slashing/v1beta1/tx_pb.ts";
+import type * as cosmos_staking_v1beta1_query from "./protos/cosmos/staking/v1beta1/query_pb.ts";
+import type * as cosmos_staking_v1beta1_tx from "./protos/cosmos/staking/v1beta1/tx_pb.ts";
+import type * as cosmos_tx_v1beta1_service from "./protos/cosmos/tx/v1beta1/service_pb.ts";
+import type * as cosmos_upgrade_v1beta1_query from "./protos/cosmos/upgrade/v1beta1/query_pb.ts";
+import type * as cosmos_upgrade_v1beta1_tx from "./protos/cosmos/upgrade/v1beta1/tx_pb.ts";
+import type * as cosmos_vesting_v1beta1_tx from "./protos/cosmos/vesting/v1beta1/tx_pb.ts";
 import { createClientFactory } from "../client/createClientFactory.ts";
 import type { Transport, CallOptions, TxCallOptions } from "../transport/types.ts";
 import type { SDKOptions } from "../sdk/types.ts";
@@ -103,7 +103,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getConfig returns the current app config.
            */
-          getConfig: withMetadata(async function getConfig(input: cosmos_app_v1alpha1_query_pb.QueryConfigRequestJson = {}, options?: CallOptions) {
+          getConfig: withMetadata(async function getConfig(input: cosmos_app_v1alpha1_query.QueryConfigRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(0);
             return getClient(service).config(input, options);
           }, { path: [0, 0] })
@@ -119,14 +119,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.43
            */
-          getAccounts: withMetadata(async function getAccounts(input: cosmos_auth_v1beta1_query_pb.QueryAccountsRequestJson, options?: CallOptions) {
+          getAccounts: withMetadata(async function getAccounts(input: cosmos_auth_v1beta1_query.QueryAccountsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).accounts(input, options);
           }, { path: [1, 0] }),
           /**
            * getAccount returns account details based on address.
            */
-          getAccount: withMetadata(async function getAccount(input: cosmos_auth_v1beta1_query_pb.QueryAccountRequestJson, options?: CallOptions) {
+          getAccount: withMetadata(async function getAccount(input: cosmos_auth_v1beta1_query.QueryAccountRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).account(input, options);
           }, { path: [1, 1] }),
@@ -135,14 +135,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46.2
            */
-          getAccountAddressByID: withMetadata(async function getAccountAddressByID(input: cosmos_auth_v1beta1_query_pb.QueryAccountAddressByIDRequestJson, options?: CallOptions) {
+          getAccountAddressByID: withMetadata(async function getAccountAddressByID(input: cosmos_auth_v1beta1_query.QueryAccountAddressByIDRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).accountAddressByID(input, options);
           }, { path: [1, 2] }),
           /**
            * getParams queries all parameters.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_auth_v1beta1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_auth_v1beta1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).params(input, options);
           }, { path: [1, 3] }),
@@ -151,14 +151,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getModuleAccounts: withMetadata(async function getModuleAccounts(input: cosmos_auth_v1beta1_query_pb.QueryModuleAccountsRequestJson = {}, options?: CallOptions) {
+          getModuleAccounts: withMetadata(async function getModuleAccounts(input: cosmos_auth_v1beta1_query.QueryModuleAccountsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).moduleAccounts(input, options);
           }, { path: [1, 4] }),
           /**
            * getModuleAccountByName returns the module account info by module name
            */
-          getModuleAccountByName: withMetadata(async function getModuleAccountByName(input: cosmos_auth_v1beta1_query_pb.QueryModuleAccountByNameRequestJson, options?: CallOptions) {
+          getModuleAccountByName: withMetadata(async function getModuleAccountByName(input: cosmos_auth_v1beta1_query.QueryModuleAccountByNameRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).moduleAccountByName(input, options);
           }, { path: [1, 5] }),
@@ -167,7 +167,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getBech32Prefix: withMetadata(async function getBech32Prefix(input: cosmos_auth_v1beta1_query_pb.Bech32PrefixRequestJson = {}, options?: CallOptions) {
+          getBech32Prefix: withMetadata(async function getBech32Prefix(input: cosmos_auth_v1beta1_query.Bech32PrefixRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).bech32Prefix(input, options);
           }, { path: [1, 6] }),
@@ -176,7 +176,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getAddressBytesToString: withMetadata(async function getAddressBytesToString(input: cosmos_auth_v1beta1_query_pb.AddressBytesToStringRequestJson, options?: CallOptions) {
+          getAddressBytesToString: withMetadata(async function getAddressBytesToString(input: cosmos_auth_v1beta1_query.AddressBytesToStringRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).addressBytesToString(input, options);
           }, { path: [1, 7] }),
@@ -185,7 +185,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getAddressStringToBytes: withMetadata(async function getAddressStringToBytes(input: cosmos_auth_v1beta1_query_pb.AddressStringToBytesRequestJson, options?: CallOptions) {
+          getAddressStringToBytes: withMetadata(async function getAddressStringToBytes(input: cosmos_auth_v1beta1_query.AddressStringToBytesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).addressStringToBytes(input, options);
           }, { path: [1, 8] }),
@@ -194,7 +194,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          getAccountInfo: withMetadata(async function getAccountInfo(input: cosmos_auth_v1beta1_query_pb.QueryAccountInfoRequestJson, options?: CallOptions) {
+          getAccountInfo: withMetadata(async function getAccountInfo(input: cosmos_auth_v1beta1_query.QueryAccountInfoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).accountInfo(input, options);
           }, { path: [1, 9] }),
@@ -204,7 +204,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_auth_v1beta1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_auth_v1beta1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(2);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [2, 0] })
@@ -215,7 +215,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * Returns list of `Authorization`, granted to the grantee by the granter.
            */
-          getGrants: withMetadata(async function getGrants(input: cosmos_authz_v1beta1_query_pb.QueryGrantsRequestJson, options?: CallOptions) {
+          getGrants: withMetadata(async function getGrants(input: cosmos_authz_v1beta1_query.QueryGrantsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(3);
             return getClient(service).grants(input, options);
           }, { path: [3, 0] }),
@@ -224,7 +224,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getGranterGrants: withMetadata(async function getGranterGrants(input: cosmos_authz_v1beta1_query_pb.QueryGranterGrantsRequestJson, options?: CallOptions) {
+          getGranterGrants: withMetadata(async function getGranterGrants(input: cosmos_authz_v1beta1_query.QueryGranterGrantsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(3);
             return getClient(service).granterGrants(input, options);
           }, { path: [3, 1] }),
@@ -233,7 +233,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getGranteeGrants: withMetadata(async function getGranteeGrants(input: cosmos_authz_v1beta1_query_pb.QueryGranteeGrantsRequestJson, options?: CallOptions) {
+          getGranteeGrants: withMetadata(async function getGranteeGrants(input: cosmos_authz_v1beta1_query.QueryGranteeGrantsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(3);
             return getClient(service).granteeGrants(input, options);
           }, { path: [3, 2] }),
@@ -243,7 +243,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * for the given (granter, grantee, Authorization) triple, then the grant
            * will be overwritten.
            */
-          grant: withMetadata(async function grant(input: cosmos_authz_v1beta1_tx_pb.MsgGrantJson, options?: TxCallOptions) {
+          grant: withMetadata(async function grant(input: cosmos_authz_v1beta1_tx.MsgGrantJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(4);
             return getMsgClient(service).grant(input, options);
           }, { path: [4, 0] }),
@@ -252,7 +252,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * authorizations granted to the grantee. Each message should have only
            * one signer corresponding to the granter of the authorization.
            */
-          exec: withMetadata(async function exec(input: cosmos_authz_v1beta1_tx_pb.MsgExecJson, options?: TxCallOptions) {
+          exec: withMetadata(async function exec(input: cosmos_authz_v1beta1_tx.MsgExecJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(4);
             return getMsgClient(service).exec(input, options);
           }, { path: [4, 1] }),
@@ -260,7 +260,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * revoke revokes any authorization corresponding to the provided method name on the
            * granter's account that has been granted to the grantee.
            */
-          revoke: withMetadata(async function revoke(input: cosmos_authz_v1beta1_tx_pb.MsgRevokeJson, options?: TxCallOptions) {
+          revoke: withMetadata(async function revoke(input: cosmos_authz_v1beta1_tx.MsgRevokeJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(4);
             return getMsgClient(service).revoke(input, options);
           }, { path: [4, 2] })
@@ -271,7 +271,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getAppOptions returns the autocli options for all of the modules in an app.
            */
-          getAppOptions: withMetadata(async function getAppOptions(input: cosmos_autocli_v1_query_pb.AppOptionsRequestJson = {}, options?: CallOptions) {
+          getAppOptions: withMetadata(async function getAppOptions(input: cosmos_autocli_v1_query.AppOptionsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getClient(service).appOptions(input, options);
           }, { path: [5, 0] })
@@ -282,7 +282,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getBalance queries the balance of a single coin for a single account.
            */
-          getBalance: withMetadata(async function getBalance(input: cosmos_bank_v1beta1_query_pb.QueryBalanceRequestJson, options?: CallOptions) {
+          getBalance: withMetadata(async function getBalance(input: cosmos_bank_v1beta1_query.QueryBalanceRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).balance(input, options);
           }, { path: [6, 0] }),
@@ -292,7 +292,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getAllBalances: withMetadata(async function getAllBalances(input: cosmos_bank_v1beta1_query_pb.QueryAllBalancesRequestJson, options?: CallOptions) {
+          getAllBalances: withMetadata(async function getAllBalances(input: cosmos_bank_v1beta1_query.QueryAllBalancesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).allBalances(input, options);
           }, { path: [6, 1] }),
@@ -305,7 +305,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getSpendableBalances: withMetadata(async function getSpendableBalances(input: cosmos_bank_v1beta1_query_pb.QuerySpendableBalancesRequestJson, options?: CallOptions) {
+          getSpendableBalances: withMetadata(async function getSpendableBalances(input: cosmos_bank_v1beta1_query.QuerySpendableBalancesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).spendableBalances(input, options);
           }, { path: [6, 2] }),
@@ -318,7 +318,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          getSpendableBalanceByDenom: withMetadata(async function getSpendableBalanceByDenom(input: cosmos_bank_v1beta1_query_pb.QuerySpendableBalanceByDenomRequestJson, options?: CallOptions) {
+          getSpendableBalanceByDenom: withMetadata(async function getSpendableBalanceByDenom(input: cosmos_bank_v1beta1_query.QuerySpendableBalanceByDenomRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).spendableBalanceByDenom(input, options);
           }, { path: [6, 3] }),
@@ -328,7 +328,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getTotalSupply: withMetadata(async function getTotalSupply(input: cosmos_bank_v1beta1_query_pb.QueryTotalSupplyRequestJson, options?: CallOptions) {
+          getTotalSupply: withMetadata(async function getTotalSupply(input: cosmos_bank_v1beta1_query.QueryTotalSupplyRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).totalSupply(input, options);
           }, { path: [6, 4] }),
@@ -338,21 +338,21 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getSupplyOf: withMetadata(async function getSupplyOf(input: cosmos_bank_v1beta1_query_pb.QuerySupplyOfRequestJson, options?: CallOptions) {
+          getSupplyOf: withMetadata(async function getSupplyOf(input: cosmos_bank_v1beta1_query.QuerySupplyOfRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).supplyOf(input, options);
           }, { path: [6, 5] }),
           /**
            * getParams queries the parameters of x/bank module.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_bank_v1beta1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_bank_v1beta1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).params(input, options);
           }, { path: [6, 6] }),
           /**
            * DenomsMetadata queries the client metadata of a given coin denomination.
            */
-          getDenomMetadata: withMetadata(async function getDenomMetadata(input: cosmos_bank_v1beta1_query_pb.QueryDenomMetadataRequestJson, options?: CallOptions) {
+          getDenomMetadata: withMetadata(async function getDenomMetadata(input: cosmos_bank_v1beta1_query.QueryDenomMetadataRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).denomMetadata(input, options);
           }, { path: [6, 7] }),
@@ -360,7 +360,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getDenomsMetadata queries the client metadata for all registered coin
            * denominations.
            */
-          getDenomsMetadata: withMetadata(async function getDenomsMetadata(input: cosmos_bank_v1beta1_query_pb.QueryDenomsMetadataRequestJson, options?: CallOptions) {
+          getDenomsMetadata: withMetadata(async function getDenomsMetadata(input: cosmos_bank_v1beta1_query.QueryDenomsMetadataRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).denomsMetadata(input, options);
           }, { path: [6, 8] }),
@@ -373,7 +373,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getDenomOwners: withMetadata(async function getDenomOwners(input: cosmos_bank_v1beta1_query_pb.QueryDenomOwnersRequestJson, options?: CallOptions) {
+          getDenomOwners: withMetadata(async function getDenomOwners(input: cosmos_bank_v1beta1_query.QueryDenomOwnersRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).denomOwners(input, options);
           }, { path: [6, 9] }),
@@ -386,21 +386,21 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          getSendEnabled: withMetadata(async function getSendEnabled(input: cosmos_bank_v1beta1_query_pb.QuerySendEnabledRequestJson, options?: CallOptions) {
+          getSendEnabled: withMetadata(async function getSendEnabled(input: cosmos_bank_v1beta1_query.QuerySendEnabledRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).sendEnabled(input, options);
           }, { path: [6, 10] }),
           /**
            * send defines a method for sending coins from one account to another account.
            */
-          send: withMetadata(async function send(input: cosmos_bank_v1beta1_tx_pb.MsgSendJson, options?: TxCallOptions) {
+          send: withMetadata(async function send(input: cosmos_bank_v1beta1_tx.MsgSendJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getMsgClient(service).send(input, options);
           }, { path: [7, 0] }),
           /**
            * multiSend defines a method for sending coins from some accounts to other accounts.
            */
-          multiSend: withMetadata(async function multiSend(input: cosmos_bank_v1beta1_tx_pb.MsgMultiSendJson, options?: TxCallOptions) {
+          multiSend: withMetadata(async function multiSend(input: cosmos_bank_v1beta1_tx.MsgMultiSendJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getMsgClient(service).multiSend(input, options);
           }, { path: [7, 1] }),
@@ -410,7 +410,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_bank_v1beta1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_bank_v1beta1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [7, 2] }),
@@ -422,7 +422,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          setSendEnabled: withMetadata(async function setSendEnabled(input: cosmos_bank_v1beta1_tx_pb.MsgSetSendEnabledJson, options?: TxCallOptions) {
+          setSendEnabled: withMetadata(async function setSendEnabled(input: cosmos_bank_v1beta1_tx.MsgSetSendEnabledJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getMsgClient(service).setSendEnabled(input, options);
           }, { path: [7, 3] })
@@ -434,7 +434,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
             /**
              * getConfig queries for the operator configuration.
              */
-            getConfig: withMetadata(async function getConfig(input: cosmos_base_node_v1beta1_query_pb.ConfigRequestJson = {}, options?: CallOptions) {
+            getConfig: withMetadata(async function getConfig(input: cosmos_base_node_v1beta1_query.ConfigRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(9);
               return getClient(service).config(input, options);
             }, { path: [9, 0] })
@@ -446,7 +446,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
              * getListAllInterfaces lists all the interfaces registered in the interface
              * registry.
              */
-            getListAllInterfaces: withMetadata(async function getListAllInterfaces(input: cosmos_base_reflection_v1beta1_reflection_pb.ListAllInterfacesRequestJson = {}, options?: CallOptions) {
+            getListAllInterfaces: withMetadata(async function getListAllInterfaces(input: cosmos_base_reflection_v1beta1_reflection.ListAllInterfacesRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(10);
               return getClient(service).listAllInterfaces(input, options);
             }, { path: [10, 0] }),
@@ -454,7 +454,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
              * getListImplementations list all the concrete types that implement a given
              * interface.
              */
-            getListImplementations: withMetadata(async function getListImplementations(input: cosmos_base_reflection_v1beta1_reflection_pb.ListImplementationsRequestJson, options?: CallOptions) {
+            getListImplementations: withMetadata(async function getListImplementations(input: cosmos_base_reflection_v1beta1_reflection.ListImplementationsRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(10);
               return getClient(service).listImplementations(input, options);
             }, { path: [10, 1] })
@@ -465,42 +465,42 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
              * NOTE: this RPC is still experimental and might be subject to breaking changes or removal in
              * future releases of the cosmos-sdk.
              */
-            getAuthnDescriptor: withMetadata(async function getAuthnDescriptor(input: cosmos_base_reflection_v2alpha1_reflection_pb.GetAuthnDescriptorRequestJson = {}, options?: CallOptions) {
+            getAuthnDescriptor: withMetadata(async function getAuthnDescriptor(input: cosmos_base_reflection_v2alpha1_reflection.GetAuthnDescriptorRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(11);
               return getClient(service).getAuthnDescriptor(input, options);
             }, { path: [11, 0] }),
             /**
              * getChainDescriptor returns the description of the chain
              */
-            getChainDescriptor: withMetadata(async function getChainDescriptor(input: cosmos_base_reflection_v2alpha1_reflection_pb.GetChainDescriptorRequestJson = {}, options?: CallOptions) {
+            getChainDescriptor: withMetadata(async function getChainDescriptor(input: cosmos_base_reflection_v2alpha1_reflection.GetChainDescriptorRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(11);
               return getClient(service).getChainDescriptor(input, options);
             }, { path: [11, 1] }),
             /**
              * getCodecDescriptor returns the descriptor of the codec of the application
              */
-            getCodecDescriptor: withMetadata(async function getCodecDescriptor(input: cosmos_base_reflection_v2alpha1_reflection_pb.GetCodecDescriptorRequestJson = {}, options?: CallOptions) {
+            getCodecDescriptor: withMetadata(async function getCodecDescriptor(input: cosmos_base_reflection_v2alpha1_reflection.GetCodecDescriptorRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(11);
               return getClient(service).getCodecDescriptor(input, options);
             }, { path: [11, 2] }),
             /**
              * getConfigurationDescriptor returns the descriptor for the sdk.Config of the application
              */
-            getConfigurationDescriptor: withMetadata(async function getConfigurationDescriptor(input: cosmos_base_reflection_v2alpha1_reflection_pb.GetConfigurationDescriptorRequestJson = {}, options?: CallOptions) {
+            getConfigurationDescriptor: withMetadata(async function getConfigurationDescriptor(input: cosmos_base_reflection_v2alpha1_reflection.GetConfigurationDescriptorRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(11);
               return getClient(service).getConfigurationDescriptor(input, options);
             }, { path: [11, 3] }),
             /**
              * getQueryServicesDescriptor returns the available gRPC queryable services of the application
              */
-            getQueryServicesDescriptor: withMetadata(async function getQueryServicesDescriptor(input: cosmos_base_reflection_v2alpha1_reflection_pb.GetQueryServicesDescriptorRequestJson = {}, options?: CallOptions) {
+            getQueryServicesDescriptor: withMetadata(async function getQueryServicesDescriptor(input: cosmos_base_reflection_v2alpha1_reflection.GetQueryServicesDescriptorRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(11);
               return getClient(service).getQueryServicesDescriptor(input, options);
             }, { path: [11, 4] }),
             /**
              * getTxDescriptor returns information on the used transaction object and available msgs that can be used
              */
-            getTxDescriptor: withMetadata(async function getTxDescriptor(input: cosmos_base_reflection_v2alpha1_reflection_pb.GetTxDescriptorRequestJson = {}, options?: CallOptions) {
+            getTxDescriptor: withMetadata(async function getTxDescriptor(input: cosmos_base_reflection_v2alpha1_reflection.GetTxDescriptorRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(11);
               return getClient(service).getTxDescriptor(input, options);
             }, { path: [11, 5] })
@@ -511,42 +511,42 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
             /**
              * getNodeInfo queries the current node info.
              */
-            getNodeInfo: withMetadata(async function getNodeInfo(input: cosmos_base_tendermint_v1beta1_query_pb.GetNodeInfoRequestJson = {}, options?: CallOptions) {
+            getNodeInfo: withMetadata(async function getNodeInfo(input: cosmos_base_tendermint_v1beta1_query.GetNodeInfoRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(12);
               return getClient(service).getNodeInfo(input, options);
             }, { path: [12, 0] }),
             /**
              * getSyncing queries node syncing.
              */
-            getSyncing: withMetadata(async function getSyncing(input: cosmos_base_tendermint_v1beta1_query_pb.GetSyncingRequestJson = {}, options?: CallOptions) {
+            getSyncing: withMetadata(async function getSyncing(input: cosmos_base_tendermint_v1beta1_query.GetSyncingRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(12);
               return getClient(service).getSyncing(input, options);
             }, { path: [12, 1] }),
             /**
              * getLatestBlock returns the latest block.
              */
-            getLatestBlock: withMetadata(async function getLatestBlock(input: cosmos_base_tendermint_v1beta1_query_pb.GetLatestBlockRequestJson = {}, options?: CallOptions) {
+            getLatestBlock: withMetadata(async function getLatestBlock(input: cosmos_base_tendermint_v1beta1_query.GetLatestBlockRequestJson = {}, options?: CallOptions) {
               const service = await serviceLoader.loadAt(12);
               return getClient(service).getLatestBlock(input, options);
             }, { path: [12, 2] }),
             /**
              * getBlockByHeight queries block for given height.
              */
-            getBlockByHeight: withMetadata(async function getBlockByHeight(input: cosmos_base_tendermint_v1beta1_query_pb.GetBlockByHeightRequestJson, options?: CallOptions) {
+            getBlockByHeight: withMetadata(async function getBlockByHeight(input: cosmos_base_tendermint_v1beta1_query.GetBlockByHeightRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(12);
               return getClient(service).getBlockByHeight(input, options);
             }, { path: [12, 3] }),
             /**
              * getLatestValidatorSet queries latest validator-set.
              */
-            getLatestValidatorSet: withMetadata(async function getLatestValidatorSet(input: cosmos_base_tendermint_v1beta1_query_pb.GetLatestValidatorSetRequestJson, options?: CallOptions) {
+            getLatestValidatorSet: withMetadata(async function getLatestValidatorSet(input: cosmos_base_tendermint_v1beta1_query.GetLatestValidatorSetRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(12);
               return getClient(service).getLatestValidatorSet(input, options);
             }, { path: [12, 4] }),
             /**
              * getValidatorSetByHeight queries validator-set at a given height.
              */
-            getValidatorSetByHeight: withMetadata(async function getValidatorSetByHeight(input: cosmos_base_tendermint_v1beta1_query_pb.GetValidatorSetByHeightRequestJson, options?: CallOptions) {
+            getValidatorSetByHeight: withMetadata(async function getValidatorSetByHeight(input: cosmos_base_tendermint_v1beta1_query.GetValidatorSetByHeightRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(12);
               return getClient(service).getValidatorSetByHeight(input, options);
             }, { path: [12, 5] }),
@@ -557,7 +557,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
              *
              * Since: cosmos-sdk 0.46
              */
-            getABCIQuery: withMetadata(async function getABCIQuery(input: cosmos_base_tendermint_v1beta1_query_pb.ABCIQueryRequestJson, options?: CallOptions) {
+            getABCIQuery: withMetadata(async function getABCIQuery(input: cosmos_base_tendermint_v1beta1_query.ABCIQueryRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(12);
               return getClient(service).aBCIQuery(input, options);
             }, { path: [12, 6] })
@@ -569,7 +569,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getParams queries the parameters of x/consensus_param module.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_consensus_v1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_consensus_v1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(13);
             return getClient(service).params(input, options);
           }, { path: [13, 0] }),
@@ -579,7 +579,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_consensus_v1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_consensus_v1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(14);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [14, 0] })
@@ -590,7 +590,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * verifyInvariant defines a method to verify a particular invariant.
            */
-          verifyInvariant: withMetadata(async function verifyInvariant(input: cosmos_crisis_v1beta1_tx_pb.MsgVerifyInvariantJson, options?: TxCallOptions) {
+          verifyInvariant: withMetadata(async function verifyInvariant(input: cosmos_crisis_v1beta1_tx.MsgVerifyInvariantJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(15);
             return getMsgClient(service).verifyInvariant(input, options);
           }, { path: [15, 0] }),
@@ -600,7 +600,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_crisis_v1beta1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_crisis_v1beta1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(15);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [15, 1] })
@@ -611,42 +611,42 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getParams queries params of the distribution module.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_distribution_v1beta1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_distribution_v1beta1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).params(input, options);
           }, { path: [16, 0] }),
           /**
            * getValidatorDistributionInfo queries validator commission and self-delegation rewards for validator
            */
-          getValidatorDistributionInfo: withMetadata(async function getValidatorDistributionInfo(input: cosmos_distribution_v1beta1_query_pb.QueryValidatorDistributionInfoRequestJson, options?: CallOptions) {
+          getValidatorDistributionInfo: withMetadata(async function getValidatorDistributionInfo(input: cosmos_distribution_v1beta1_query.QueryValidatorDistributionInfoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).validatorDistributionInfo(input, options);
           }, { path: [16, 1] }),
           /**
            * getValidatorOutstandingRewards queries rewards of a validator address.
            */
-          getValidatorOutstandingRewards: withMetadata(async function getValidatorOutstandingRewards(input: cosmos_distribution_v1beta1_query_pb.QueryValidatorOutstandingRewardsRequestJson, options?: CallOptions) {
+          getValidatorOutstandingRewards: withMetadata(async function getValidatorOutstandingRewards(input: cosmos_distribution_v1beta1_query.QueryValidatorOutstandingRewardsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).validatorOutstandingRewards(input, options);
           }, { path: [16, 2] }),
           /**
            * getValidatorCommission queries accumulated commission for a validator.
            */
-          getValidatorCommission: withMetadata(async function getValidatorCommission(input: cosmos_distribution_v1beta1_query_pb.QueryValidatorCommissionRequestJson, options?: CallOptions) {
+          getValidatorCommission: withMetadata(async function getValidatorCommission(input: cosmos_distribution_v1beta1_query.QueryValidatorCommissionRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).validatorCommission(input, options);
           }, { path: [16, 3] }),
           /**
            * getValidatorSlashes queries slash events of a validator.
            */
-          getValidatorSlashes: withMetadata(async function getValidatorSlashes(input: cosmos_distribution_v1beta1_query_pb.QueryValidatorSlashesRequestJson, options?: CallOptions) {
+          getValidatorSlashes: withMetadata(async function getValidatorSlashes(input: cosmos_distribution_v1beta1_query.QueryValidatorSlashesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).validatorSlashes(input, options);
           }, { path: [16, 4] }),
           /**
            * getDelegationRewards queries the total rewards accrued by a delegation.
            */
-          getDelegationRewards: withMetadata(async function getDelegationRewards(input: cosmos_distribution_v1beta1_query_pb.QueryDelegationRewardsRequestJson, options?: CallOptions) {
+          getDelegationRewards: withMetadata(async function getDelegationRewards(input: cosmos_distribution_v1beta1_query.QueryDelegationRewardsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).delegationRewards(input, options);
           }, { path: [16, 5] }),
@@ -654,35 +654,35 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getDelegationTotalRewards queries the total rewards accrued by a each
            * validator.
            */
-          getDelegationTotalRewards: withMetadata(async function getDelegationTotalRewards(input: cosmos_distribution_v1beta1_query_pb.QueryDelegationTotalRewardsRequestJson, options?: CallOptions) {
+          getDelegationTotalRewards: withMetadata(async function getDelegationTotalRewards(input: cosmos_distribution_v1beta1_query.QueryDelegationTotalRewardsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).delegationTotalRewards(input, options);
           }, { path: [16, 6] }),
           /**
            * getDelegatorValidators queries the validators of a delegator.
            */
-          getDelegatorValidators: withMetadata(async function getDelegatorValidators(input: cosmos_distribution_v1beta1_query_pb.QueryDelegatorValidatorsRequestJson, options?: CallOptions) {
+          getDelegatorValidators: withMetadata(async function getDelegatorValidators(input: cosmos_distribution_v1beta1_query.QueryDelegatorValidatorsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).delegatorValidators(input, options);
           }, { path: [16, 7] }),
           /**
            * getDelegatorWithdrawAddress queries withdraw address of a delegator.
            */
-          getDelegatorWithdrawAddress: withMetadata(async function getDelegatorWithdrawAddress(input: cosmos_distribution_v1beta1_query_pb.QueryDelegatorWithdrawAddressRequestJson, options?: CallOptions) {
+          getDelegatorWithdrawAddress: withMetadata(async function getDelegatorWithdrawAddress(input: cosmos_distribution_v1beta1_query.QueryDelegatorWithdrawAddressRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).delegatorWithdrawAddress(input, options);
           }, { path: [16, 8] }),
           /**
            * getCommunityPool queries the community pool coins.
            */
-          getCommunityPool: withMetadata(async function getCommunityPool(input: cosmos_distribution_v1beta1_query_pb.QueryCommunityPoolRequestJson = {}, options?: CallOptions) {
+          getCommunityPool: withMetadata(async function getCommunityPool(input: cosmos_distribution_v1beta1_query.QueryCommunityPoolRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).communityPool(input, options);
           }, { path: [16, 9] }),
           /**
            * getTokenizeShareRecordReward queries the tokenize share record rewards
            */
-          getTokenizeShareRecordReward: withMetadata(async function getTokenizeShareRecordReward(input: cosmos_distribution_v1beta1_query_pb.QueryTokenizeShareRecordRewardRequestJson, options?: CallOptions) {
+          getTokenizeShareRecordReward: withMetadata(async function getTokenizeShareRecordReward(input: cosmos_distribution_v1beta1_query.QueryTokenizeShareRecordRewardRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(16);
             return getClient(service).tokenizeShareRecordReward(input, options);
           }, { path: [16, 10] }),
@@ -690,7 +690,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * setWithdrawAddress defines a method to change the withdraw address
            * for a delegator (or validator self-delegation).
            */
-          setWithdrawAddress: withMetadata(async function setWithdrawAddress(input: cosmos_distribution_v1beta1_tx_pb.MsgSetWithdrawAddressJson, options?: TxCallOptions) {
+          setWithdrawAddress: withMetadata(async function setWithdrawAddress(input: cosmos_distribution_v1beta1_tx.MsgSetWithdrawAddressJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).setWithdrawAddress(input, options);
           }, { path: [17, 0] }),
@@ -698,7 +698,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * withdrawDelegatorReward defines a method to withdraw rewards of delegator
            * from a single validator.
            */
-          withdrawDelegatorReward: withMetadata(async function withdrawDelegatorReward(input: cosmos_distribution_v1beta1_tx_pb.MsgWithdrawDelegatorRewardJson, options?: TxCallOptions) {
+          withdrawDelegatorReward: withMetadata(async function withdrawDelegatorReward(input: cosmos_distribution_v1beta1_tx.MsgWithdrawDelegatorRewardJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).withdrawDelegatorReward(input, options);
           }, { path: [17, 1] }),
@@ -706,7 +706,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * withdrawValidatorCommission defines a method to withdraw the
            * full commission to the validator address.
            */
-          withdrawValidatorCommission: withMetadata(async function withdrawValidatorCommission(input: cosmos_distribution_v1beta1_tx_pb.MsgWithdrawValidatorCommissionJson, options?: TxCallOptions) {
+          withdrawValidatorCommission: withMetadata(async function withdrawValidatorCommission(input: cosmos_distribution_v1beta1_tx.MsgWithdrawValidatorCommissionJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).withdrawValidatorCommission(input, options);
           }, { path: [17, 2] }),
@@ -714,7 +714,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * fundCommunityPool defines a method to allow an account to directly
            * fund the community pool.
            */
-          fundCommunityPool: withMetadata(async function fundCommunityPool(input: cosmos_distribution_v1beta1_tx_pb.MsgFundCommunityPoolJson, options?: TxCallOptions) {
+          fundCommunityPool: withMetadata(async function fundCommunityPool(input: cosmos_distribution_v1beta1_tx.MsgFundCommunityPoolJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).fundCommunityPool(input, options);
           }, { path: [17, 3] }),
@@ -724,7 +724,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_distribution_v1beta1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_distribution_v1beta1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [17, 4] }),
@@ -736,21 +736,21 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          communityPoolSpend: withMetadata(async function communityPoolSpend(input: cosmos_distribution_v1beta1_tx_pb.MsgCommunityPoolSpendJson, options?: TxCallOptions) {
+          communityPoolSpend: withMetadata(async function communityPoolSpend(input: cosmos_distribution_v1beta1_tx.MsgCommunityPoolSpendJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).communityPoolSpend(input, options);
           }, { path: [17, 5] }),
           /**
            * withdrawTokenizeShareRecordReward defines a method to withdraw reward for an owning TokenizeShareRecord
            */
-          withdrawTokenizeShareRecordReward: withMetadata(async function withdrawTokenizeShareRecordReward(input: cosmos_distribution_v1beta1_tx_pb.MsgWithdrawTokenizeShareRecordRewardJson, options?: TxCallOptions) {
+          withdrawTokenizeShareRecordReward: withMetadata(async function withdrawTokenizeShareRecordReward(input: cosmos_distribution_v1beta1_tx.MsgWithdrawTokenizeShareRecordRewardJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).withdrawTokenizeShareRecordReward(input, options);
           }, { path: [17, 6] }),
           /**
            * withdrawAllTokenizeShareRecordReward defines a method to withdraw reward for all owning TokenizeShareRecord
            */
-          withdrawAllTokenizeShareRecordReward: withMetadata(async function withdrawAllTokenizeShareRecordReward(input: cosmos_distribution_v1beta1_tx_pb.MsgWithdrawAllTokenizeShareRecordRewardJson, options?: TxCallOptions) {
+          withdrawAllTokenizeShareRecordReward: withMetadata(async function withdrawAllTokenizeShareRecordReward(input: cosmos_distribution_v1beta1_tx.MsgWithdrawAllTokenizeShareRecordRewardJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(17);
             return getMsgClient(service).withdrawAllTokenizeShareRecordReward(input, options);
           }, { path: [17, 7] })
@@ -761,14 +761,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getEvidence queries evidence based on evidence hash.
            */
-          getEvidence: withMetadata(async function getEvidence(input: cosmos_evidence_v1beta1_query_pb.QueryEvidenceRequestJson, options?: CallOptions) {
+          getEvidence: withMetadata(async function getEvidence(input: cosmos_evidence_v1beta1_query.QueryEvidenceRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(18);
             return getClient(service).evidence(input, options);
           }, { path: [18, 0] }),
           /**
            * getAllEvidence queries all evidence.
            */
-          getAllEvidence: withMetadata(async function getAllEvidence(input: cosmos_evidence_v1beta1_query_pb.QueryAllEvidenceRequestJson, options?: CallOptions) {
+          getAllEvidence: withMetadata(async function getAllEvidence(input: cosmos_evidence_v1beta1_query.QueryAllEvidenceRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(18);
             return getClient(service).allEvidence(input, options);
           }, { path: [18, 1] }),
@@ -776,7 +776,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * submitEvidence submits an arbitrary Evidence of misbehavior such as equivocation or
            * counterfactual signing.
            */
-          submitEvidence: withMetadata(async function submitEvidence(input: cosmos_evidence_v1beta1_tx_pb.MsgSubmitEvidenceJson, options?: TxCallOptions) {
+          submitEvidence: withMetadata(async function submitEvidence(input: cosmos_evidence_v1beta1_tx.MsgSubmitEvidenceJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(19);
             return getMsgClient(service).submitEvidence(input, options);
           }, { path: [19, 0] })
@@ -787,14 +787,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getAllowance returns fee granted to the grantee by the granter.
            */
-          getAllowance: withMetadata(async function getAllowance(input: cosmos_feegrant_v1beta1_query_pb.QueryAllowanceRequestJson, options?: CallOptions) {
+          getAllowance: withMetadata(async function getAllowance(input: cosmos_feegrant_v1beta1_query.QueryAllowanceRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(20);
             return getClient(service).allowance(input, options);
           }, { path: [20, 0] }),
           /**
            * getAllowances returns all the grants for address.
            */
-          getAllowances: withMetadata(async function getAllowances(input: cosmos_feegrant_v1beta1_query_pb.QueryAllowancesRequestJson, options?: CallOptions) {
+          getAllowances: withMetadata(async function getAllowances(input: cosmos_feegrant_v1beta1_query.QueryAllowancesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(20);
             return getClient(service).allowances(input, options);
           }, { path: [20, 1] }),
@@ -803,7 +803,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getAllowancesByGranter: withMetadata(async function getAllowancesByGranter(input: cosmos_feegrant_v1beta1_query_pb.QueryAllowancesByGranterRequestJson, options?: CallOptions) {
+          getAllowancesByGranter: withMetadata(async function getAllowancesByGranter(input: cosmos_feegrant_v1beta1_query.QueryAllowancesByGranterRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(20);
             return getClient(service).allowancesByGranter(input, options);
           }, { path: [20, 2] }),
@@ -811,7 +811,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * grantAllowance grants fee allowance to the grantee on the granter's
            * account with the provided expiration time.
            */
-          grantAllowance: withMetadata(async function grantAllowance(input: cosmos_feegrant_v1beta1_tx_pb.MsgGrantAllowanceJson, options?: TxCallOptions) {
+          grantAllowance: withMetadata(async function grantAllowance(input: cosmos_feegrant_v1beta1_tx.MsgGrantAllowanceJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(21);
             return getMsgClient(service).grantAllowance(input, options);
           }, { path: [21, 0] }),
@@ -819,7 +819,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * revokeAllowance revokes any fee allowance of granter's account that
            * has been granted to the grantee.
            */
-          revokeAllowance: withMetadata(async function revokeAllowance(input: cosmos_feegrant_v1beta1_tx_pb.MsgRevokeAllowanceJson, options?: TxCallOptions) {
+          revokeAllowance: withMetadata(async function revokeAllowance(input: cosmos_feegrant_v1beta1_tx.MsgRevokeAllowanceJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(21);
             return getMsgClient(service).revokeAllowance(input, options);
           }, { path: [21, 1] })
@@ -830,63 +830,63 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getProposal queries proposal details based on ProposalID.
            */
-          getProposal: withMetadata(async function getProposal(input: cosmos_gov_v1_query_pb.QueryProposalRequestJson, options?: CallOptions) {
+          getProposal: withMetadata(async function getProposal(input: cosmos_gov_v1_query.QueryProposalRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).proposal(input, options);
           }, { path: [22, 0] }),
           /**
            * getProposals queries all proposals based on given status.
            */
-          getProposals: withMetadata(async function getProposals(input: cosmos_gov_v1_query_pb.QueryProposalsRequestJson, options?: CallOptions) {
+          getProposals: withMetadata(async function getProposals(input: cosmos_gov_v1_query.QueryProposalsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).proposals(input, options);
           }, { path: [22, 1] }),
           /**
            * getVote queries voted information based on proposalID, voterAddr.
            */
-          getVote: withMetadata(async function getVote(input: cosmos_gov_v1_query_pb.QueryVoteRequestJson, options?: CallOptions) {
+          getVote: withMetadata(async function getVote(input: cosmos_gov_v1_query.QueryVoteRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).vote(input, options);
           }, { path: [22, 2] }),
           /**
            * getVotes queries votes of a given proposal.
            */
-          getVotes: withMetadata(async function getVotes(input: cosmos_gov_v1_query_pb.QueryVotesRequestJson, options?: CallOptions) {
+          getVotes: withMetadata(async function getVotes(input: cosmos_gov_v1_query.QueryVotesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).votes(input, options);
           }, { path: [22, 3] }),
           /**
            * getParams queries all parameters of the gov module.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_gov_v1_query_pb.QueryParamsRequestJson, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_gov_v1_query.QueryParamsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).params(input, options);
           }, { path: [22, 4] }),
           /**
            * getDeposit queries single deposit information based proposalID, depositAddr.
            */
-          getDeposit: withMetadata(async function getDeposit(input: cosmos_gov_v1_query_pb.QueryDepositRequestJson, options?: CallOptions) {
+          getDeposit: withMetadata(async function getDeposit(input: cosmos_gov_v1_query.QueryDepositRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).deposit(input, options);
           }, { path: [22, 5] }),
           /**
            * getDeposits queries all deposits of a single proposal.
            */
-          getDeposits: withMetadata(async function getDeposits(input: cosmos_gov_v1_query_pb.QueryDepositsRequestJson, options?: CallOptions) {
+          getDeposits: withMetadata(async function getDeposits(input: cosmos_gov_v1_query.QueryDepositsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).deposits(input, options);
           }, { path: [22, 6] }),
           /**
            * getTallyResult queries the tally of a proposal vote.
            */
-          getTallyResult: withMetadata(async function getTallyResult(input: cosmos_gov_v1_query_pb.QueryTallyResultRequestJson, options?: CallOptions) {
+          getTallyResult: withMetadata(async function getTallyResult(input: cosmos_gov_v1_query.QueryTallyResultRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(22);
             return getClient(service).tallyResult(input, options);
           }, { path: [22, 7] }),
           /**
            * submitProposal defines a method to create new proposal given the messages.
            */
-          submitProposal: withMetadata(async function submitProposal(input: cosmos_gov_v1_tx_pb.MsgSubmitProposalJson, options?: TxCallOptions) {
+          submitProposal: withMetadata(async function submitProposal(input: cosmos_gov_v1_tx.MsgSubmitProposalJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(23);
             return getMsgClient(service).submitProposal(input, options);
           }, { path: [23, 0] }),
@@ -894,28 +894,28 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * execLegacyContent defines a Msg to be in included in a MsgSubmitProposal
            * to execute a legacy content-based proposal.
            */
-          execLegacyContent: withMetadata(async function execLegacyContent(input: cosmos_gov_v1_tx_pb.MsgExecLegacyContentJson, options?: TxCallOptions) {
+          execLegacyContent: withMetadata(async function execLegacyContent(input: cosmos_gov_v1_tx.MsgExecLegacyContentJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(23);
             return getMsgClient(service).execLegacyContent(input, options);
           }, { path: [23, 1] }),
           /**
            * vote defines a method to add a vote on a specific proposal.
            */
-          vote: withMetadata(async function vote(input: cosmos_gov_v1_tx_pb.MsgVoteJson, options?: TxCallOptions) {
+          vote: withMetadata(async function vote(input: cosmos_gov_v1_tx.MsgVoteJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(23);
             return getMsgClient(service).vote(input, options);
           }, { path: [23, 2] }),
           /**
            * voteWeighted defines a method to add a weighted vote on a specific proposal.
            */
-          voteWeighted: withMetadata(async function voteWeighted(input: cosmos_gov_v1_tx_pb.MsgVoteWeightedJson, options?: TxCallOptions) {
+          voteWeighted: withMetadata(async function voteWeighted(input: cosmos_gov_v1_tx.MsgVoteWeightedJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(23);
             return getMsgClient(service).voteWeighted(input, options);
           }, { path: [23, 3] }),
           /**
            * deposit defines a method to add deposit on a specific proposal.
            */
-          deposit: withMetadata(async function deposit(input: cosmos_gov_v1_tx_pb.MsgDepositJson, options?: TxCallOptions) {
+          deposit: withMetadata(async function deposit(input: cosmos_gov_v1_tx.MsgDepositJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(23);
             return getMsgClient(service).deposit(input, options);
           }, { path: [23, 4] }),
@@ -925,7 +925,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_gov_v1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_gov_v1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(23);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [23, 5] })
@@ -934,70 +934,70 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getProposal queries proposal details based on ProposalID.
            */
-          getProposal: withMetadata(async function getProposal(input: cosmos_gov_v1beta1_query_pb.QueryProposalRequestJson, options?: CallOptions) {
+          getProposal: withMetadata(async function getProposal(input: cosmos_gov_v1beta1_query.QueryProposalRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).proposal(input, options);
           }, { path: [24, 0] }),
           /**
            * getProposals queries all proposals based on given status.
            */
-          getProposals: withMetadata(async function getProposals(input: cosmos_gov_v1beta1_query_pb.QueryProposalsRequestJson, options?: CallOptions) {
+          getProposals: withMetadata(async function getProposals(input: cosmos_gov_v1beta1_query.QueryProposalsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).proposals(input, options);
           }, { path: [24, 1] }),
           /**
            * getVote queries voted information based on proposalID, voterAddr.
            */
-          getVote: withMetadata(async function getVote(input: cosmos_gov_v1beta1_query_pb.QueryVoteRequestJson, options?: CallOptions) {
+          getVote: withMetadata(async function getVote(input: cosmos_gov_v1beta1_query.QueryVoteRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).vote(input, options);
           }, { path: [24, 2] }),
           /**
            * getVotes queries votes of a given proposal.
            */
-          getVotes: withMetadata(async function getVotes(input: cosmos_gov_v1beta1_query_pb.QueryVotesRequestJson, options?: CallOptions) {
+          getVotes: withMetadata(async function getVotes(input: cosmos_gov_v1beta1_query.QueryVotesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).votes(input, options);
           }, { path: [24, 3] }),
           /**
            * getParams queries all parameters of the gov module.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_gov_v1beta1_query_pb.QueryParamsRequestJson, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_gov_v1beta1_query.QueryParamsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).params(input, options);
           }, { path: [24, 4] }),
           /**
            * getDeposit queries single deposit information based proposalID, depositAddr.
            */
-          getDeposit: withMetadata(async function getDeposit(input: cosmos_gov_v1beta1_query_pb.QueryDepositRequestJson, options?: CallOptions) {
+          getDeposit: withMetadata(async function getDeposit(input: cosmos_gov_v1beta1_query.QueryDepositRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).deposit(input, options);
           }, { path: [24, 5] }),
           /**
            * getDeposits queries all deposits of a single proposal.
            */
-          getDeposits: withMetadata(async function getDeposits(input: cosmos_gov_v1beta1_query_pb.QueryDepositsRequestJson, options?: CallOptions) {
+          getDeposits: withMetadata(async function getDeposits(input: cosmos_gov_v1beta1_query.QueryDepositsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).deposits(input, options);
           }, { path: [24, 6] }),
           /**
            * getTallyResult queries the tally of a proposal vote.
            */
-          getTallyResult: withMetadata(async function getTallyResult(input: cosmos_gov_v1beta1_query_pb.QueryTallyResultRequestJson, options?: CallOptions) {
+          getTallyResult: withMetadata(async function getTallyResult(input: cosmos_gov_v1beta1_query.QueryTallyResultRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(24);
             return getClient(service).tallyResult(input, options);
           }, { path: [24, 7] }),
           /**
            * submitProposal defines a method to create new proposal given a content.
            */
-          submitProposal: withMetadata(async function submitProposal(input: cosmos_gov_v1beta1_tx_pb.MsgSubmitProposalJson, options?: TxCallOptions) {
+          submitProposal: withMetadata(async function submitProposal(input: cosmos_gov_v1beta1_tx.MsgSubmitProposalJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(25);
             return getMsgClient(service).submitProposal(input, options);
           }, { path: [25, 0] }),
           /**
            * vote defines a method to add a vote on a specific proposal.
            */
-          vote: withMetadata(async function vote(input: cosmos_gov_v1beta1_tx_pb.MsgVoteJson, options?: TxCallOptions) {
+          vote: withMetadata(async function vote(input: cosmos_gov_v1beta1_tx.MsgVoteJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(25);
             return getMsgClient(service).vote(input, options);
           }, { path: [25, 1] }),
@@ -1006,14 +1006,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.43
            */
-          voteWeighted: withMetadata(async function voteWeighted(input: cosmos_gov_v1beta1_tx_pb.MsgVoteWeightedJson, options?: TxCallOptions) {
+          voteWeighted: withMetadata(async function voteWeighted(input: cosmos_gov_v1beta1_tx.MsgVoteWeightedJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(25);
             return getMsgClient(service).voteWeighted(input, options);
           }, { path: [25, 2] }),
           /**
            * deposit defines a method to add deposit on a specific proposal.
            */
-          deposit: withMetadata(async function deposit(input: cosmos_gov_v1beta1_tx_pb.MsgDepositJson, options?: TxCallOptions) {
+          deposit: withMetadata(async function deposit(input: cosmos_gov_v1beta1_tx.MsgDepositJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(25);
             return getMsgClient(service).deposit(input, options);
           }, { path: [25, 3] })
@@ -1024,84 +1024,84 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getGroupInfo queries group info based on group id.
            */
-          getGroupInfo: withMetadata(async function getGroupInfo(input: cosmos_group_v1_query_pb.QueryGroupInfoRequestJson, options?: CallOptions) {
+          getGroupInfo: withMetadata(async function getGroupInfo(input: cosmos_group_v1_query.QueryGroupInfoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groupInfo(input, options);
           }, { path: [26, 0] }),
           /**
            * getGroupPolicyInfo queries group policy info based on account address of group policy.
            */
-          getGroupPolicyInfo: withMetadata(async function getGroupPolicyInfo(input: cosmos_group_v1_query_pb.QueryGroupPolicyInfoRequestJson, options?: CallOptions) {
+          getGroupPolicyInfo: withMetadata(async function getGroupPolicyInfo(input: cosmos_group_v1_query.QueryGroupPolicyInfoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groupPolicyInfo(input, options);
           }, { path: [26, 1] }),
           /**
            * getGroupMembers queries members of a group by group id.
            */
-          getGroupMembers: withMetadata(async function getGroupMembers(input: cosmos_group_v1_query_pb.QueryGroupMembersRequestJson, options?: CallOptions) {
+          getGroupMembers: withMetadata(async function getGroupMembers(input: cosmos_group_v1_query.QueryGroupMembersRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groupMembers(input, options);
           }, { path: [26, 2] }),
           /**
            * getGroupsByAdmin queries groups by admin address.
            */
-          getGroupsByAdmin: withMetadata(async function getGroupsByAdmin(input: cosmos_group_v1_query_pb.QueryGroupsByAdminRequestJson, options?: CallOptions) {
+          getGroupsByAdmin: withMetadata(async function getGroupsByAdmin(input: cosmos_group_v1_query.QueryGroupsByAdminRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groupsByAdmin(input, options);
           }, { path: [26, 3] }),
           /**
            * getGroupPoliciesByGroup queries group policies by group id.
            */
-          getGroupPoliciesByGroup: withMetadata(async function getGroupPoliciesByGroup(input: cosmos_group_v1_query_pb.QueryGroupPoliciesByGroupRequestJson, options?: CallOptions) {
+          getGroupPoliciesByGroup: withMetadata(async function getGroupPoliciesByGroup(input: cosmos_group_v1_query.QueryGroupPoliciesByGroupRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groupPoliciesByGroup(input, options);
           }, { path: [26, 4] }),
           /**
            * getGroupPoliciesByAdmin queries group policies by admin address.
            */
-          getGroupPoliciesByAdmin: withMetadata(async function getGroupPoliciesByAdmin(input: cosmos_group_v1_query_pb.QueryGroupPoliciesByAdminRequestJson, options?: CallOptions) {
+          getGroupPoliciesByAdmin: withMetadata(async function getGroupPoliciesByAdmin(input: cosmos_group_v1_query.QueryGroupPoliciesByAdminRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groupPoliciesByAdmin(input, options);
           }, { path: [26, 5] }),
           /**
            * getProposal queries a proposal based on proposal id.
            */
-          getProposal: withMetadata(async function getProposal(input: cosmos_group_v1_query_pb.QueryProposalRequestJson, options?: CallOptions) {
+          getProposal: withMetadata(async function getProposal(input: cosmos_group_v1_query.QueryProposalRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).proposal(input, options);
           }, { path: [26, 6] }),
           /**
            * getProposalsByGroupPolicy queries proposals based on account address of group policy.
            */
-          getProposalsByGroupPolicy: withMetadata(async function getProposalsByGroupPolicy(input: cosmos_group_v1_query_pb.QueryProposalsByGroupPolicyRequestJson, options?: CallOptions) {
+          getProposalsByGroupPolicy: withMetadata(async function getProposalsByGroupPolicy(input: cosmos_group_v1_query.QueryProposalsByGroupPolicyRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).proposalsByGroupPolicy(input, options);
           }, { path: [26, 7] }),
           /**
            * getVoteByProposalVoter queries a vote by proposal id and voter.
            */
-          getVoteByProposalVoter: withMetadata(async function getVoteByProposalVoter(input: cosmos_group_v1_query_pb.QueryVoteByProposalVoterRequestJson, options?: CallOptions) {
+          getVoteByProposalVoter: withMetadata(async function getVoteByProposalVoter(input: cosmos_group_v1_query.QueryVoteByProposalVoterRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).voteByProposalVoter(input, options);
           }, { path: [26, 8] }),
           /**
            * getVotesByProposal queries a vote by proposal id.
            */
-          getVotesByProposal: withMetadata(async function getVotesByProposal(input: cosmos_group_v1_query_pb.QueryVotesByProposalRequestJson, options?: CallOptions) {
+          getVotesByProposal: withMetadata(async function getVotesByProposal(input: cosmos_group_v1_query.QueryVotesByProposalRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).votesByProposal(input, options);
           }, { path: [26, 9] }),
           /**
            * getVotesByVoter queries a vote by voter.
            */
-          getVotesByVoter: withMetadata(async function getVotesByVoter(input: cosmos_group_v1_query_pb.QueryVotesByVoterRequestJson, options?: CallOptions) {
+          getVotesByVoter: withMetadata(async function getVotesByVoter(input: cosmos_group_v1_query.QueryVotesByVoterRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).votesByVoter(input, options);
           }, { path: [26, 10] }),
           /**
            * getGroupsByMember queries groups by member address.
            */
-          getGroupsByMember: withMetadata(async function getGroupsByMember(input: cosmos_group_v1_query_pb.QueryGroupsByMemberRequestJson, options?: CallOptions) {
+          getGroupsByMember: withMetadata(async function getGroupsByMember(input: cosmos_group_v1_query.QueryGroupsByMemberRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groupsByMember(input, options);
           }, { path: [26, 11] }),
@@ -1112,7 +1112,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * then it simply returns the `final_tally_result` state stored in the
            * proposal itself.
            */
-          getTallyResult: withMetadata(async function getTallyResult(input: cosmos_group_v1_query_pb.QueryTallyResultRequestJson, options?: CallOptions) {
+          getTallyResult: withMetadata(async function getTallyResult(input: cosmos_group_v1_query.QueryTallyResultRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).tallyResult(input, options);
           }, { path: [26, 12] }),
@@ -1121,105 +1121,105 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47.1
            */
-          getGroups: withMetadata(async function getGroups(input: cosmos_group_v1_query_pb.QueryGroupsRequestJson, options?: CallOptions) {
+          getGroups: withMetadata(async function getGroups(input: cosmos_group_v1_query.QueryGroupsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(26);
             return getClient(service).groups(input, options);
           }, { path: [26, 13] }),
           /**
            * createGroup creates a new group with an admin account address, a list of members and some optional metadata.
            */
-          createGroup: withMetadata(async function createGroup(input: cosmos_group_v1_tx_pb.MsgCreateGroupJson, options?: TxCallOptions) {
+          createGroup: withMetadata(async function createGroup(input: cosmos_group_v1_tx.MsgCreateGroupJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).createGroup(input, options);
           }, { path: [27, 0] }),
           /**
            * updateGroupMembers updates the group members with given group id and admin address.
            */
-          updateGroupMembers: withMetadata(async function updateGroupMembers(input: cosmos_group_v1_tx_pb.MsgUpdateGroupMembersJson, options?: TxCallOptions) {
+          updateGroupMembers: withMetadata(async function updateGroupMembers(input: cosmos_group_v1_tx.MsgUpdateGroupMembersJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).updateGroupMembers(input, options);
           }, { path: [27, 1] }),
           /**
            * updateGroupAdmin updates the group admin with given group id and previous admin address.
            */
-          updateGroupAdmin: withMetadata(async function updateGroupAdmin(input: cosmos_group_v1_tx_pb.MsgUpdateGroupAdminJson, options?: TxCallOptions) {
+          updateGroupAdmin: withMetadata(async function updateGroupAdmin(input: cosmos_group_v1_tx.MsgUpdateGroupAdminJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).updateGroupAdmin(input, options);
           }, { path: [27, 2] }),
           /**
            * updateGroupMetadata updates the group metadata with given group id and admin address.
            */
-          updateGroupMetadata: withMetadata(async function updateGroupMetadata(input: cosmos_group_v1_tx_pb.MsgUpdateGroupMetadataJson, options?: TxCallOptions) {
+          updateGroupMetadata: withMetadata(async function updateGroupMetadata(input: cosmos_group_v1_tx.MsgUpdateGroupMetadataJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).updateGroupMetadata(input, options);
           }, { path: [27, 3] }),
           /**
            * createGroupPolicy creates a new group policy using given DecisionPolicy.
            */
-          createGroupPolicy: withMetadata(async function createGroupPolicy(input: cosmos_group_v1_tx_pb.MsgCreateGroupPolicyJson, options?: TxCallOptions) {
+          createGroupPolicy: withMetadata(async function createGroupPolicy(input: cosmos_group_v1_tx.MsgCreateGroupPolicyJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).createGroupPolicy(input, options);
           }, { path: [27, 4] }),
           /**
            * createGroupWithPolicy creates a new group with policy.
            */
-          createGroupWithPolicy: withMetadata(async function createGroupWithPolicy(input: cosmos_group_v1_tx_pb.MsgCreateGroupWithPolicyJson, options?: TxCallOptions) {
+          createGroupWithPolicy: withMetadata(async function createGroupWithPolicy(input: cosmos_group_v1_tx.MsgCreateGroupWithPolicyJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).createGroupWithPolicy(input, options);
           }, { path: [27, 5] }),
           /**
            * updateGroupPolicyAdmin updates a group policy admin.
            */
-          updateGroupPolicyAdmin: withMetadata(async function updateGroupPolicyAdmin(input: cosmos_group_v1_tx_pb.MsgUpdateGroupPolicyAdminJson, options?: TxCallOptions) {
+          updateGroupPolicyAdmin: withMetadata(async function updateGroupPolicyAdmin(input: cosmos_group_v1_tx.MsgUpdateGroupPolicyAdminJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).updateGroupPolicyAdmin(input, options);
           }, { path: [27, 6] }),
           /**
            * updateGroupPolicyDecisionPolicy allows a group policy's decision policy to be updated.
            */
-          updateGroupPolicyDecisionPolicy: withMetadata(async function updateGroupPolicyDecisionPolicy(input: cosmos_group_v1_tx_pb.MsgUpdateGroupPolicyDecisionPolicyJson, options?: TxCallOptions) {
+          updateGroupPolicyDecisionPolicy: withMetadata(async function updateGroupPolicyDecisionPolicy(input: cosmos_group_v1_tx.MsgUpdateGroupPolicyDecisionPolicyJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).updateGroupPolicyDecisionPolicy(input, options);
           }, { path: [27, 7] }),
           /**
            * updateGroupPolicyMetadata updates a group policy metadata.
            */
-          updateGroupPolicyMetadata: withMetadata(async function updateGroupPolicyMetadata(input: cosmos_group_v1_tx_pb.MsgUpdateGroupPolicyMetadataJson, options?: TxCallOptions) {
+          updateGroupPolicyMetadata: withMetadata(async function updateGroupPolicyMetadata(input: cosmos_group_v1_tx.MsgUpdateGroupPolicyMetadataJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).updateGroupPolicyMetadata(input, options);
           }, { path: [27, 8] }),
           /**
            * submitProposal submits a new proposal.
            */
-          submitProposal: withMetadata(async function submitProposal(input: cosmos_group_v1_tx_pb.MsgSubmitProposalJson, options?: TxCallOptions) {
+          submitProposal: withMetadata(async function submitProposal(input: cosmos_group_v1_tx.MsgSubmitProposalJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).submitProposal(input, options);
           }, { path: [27, 9] }),
           /**
            * withdrawProposal withdraws a proposal.
            */
-          withdrawProposal: withMetadata(async function withdrawProposal(input: cosmos_group_v1_tx_pb.MsgWithdrawProposalJson, options?: TxCallOptions) {
+          withdrawProposal: withMetadata(async function withdrawProposal(input: cosmos_group_v1_tx.MsgWithdrawProposalJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).withdrawProposal(input, options);
           }, { path: [27, 10] }),
           /**
            * vote allows a voter to vote on a proposal.
            */
-          vote: withMetadata(async function vote(input: cosmos_group_v1_tx_pb.MsgVoteJson, options?: TxCallOptions) {
+          vote: withMetadata(async function vote(input: cosmos_group_v1_tx.MsgVoteJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).vote(input, options);
           }, { path: [27, 11] }),
           /**
            * exec executes a proposal.
            */
-          exec: withMetadata(async function exec(input: cosmos_group_v1_tx_pb.MsgExecJson, options?: TxCallOptions) {
+          exec: withMetadata(async function exec(input: cosmos_group_v1_tx.MsgExecJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).exec(input, options);
           }, { path: [27, 12] }),
           /**
            * leaveGroup allows a group member to leave the group.
            */
-          leaveGroup: withMetadata(async function leaveGroup(input: cosmos_group_v1_tx_pb.MsgLeaveGroupJson, options?: TxCallOptions) {
+          leaveGroup: withMetadata(async function leaveGroup(input: cosmos_group_v1_tx.MsgLeaveGroupJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(27);
             return getMsgClient(service).leaveGroup(input, options);
           }, { path: [27, 13] })
@@ -1230,21 +1230,21 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getParams returns the total set of minting parameters.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_mint_v1beta1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_mint_v1beta1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(28);
             return getClient(service).params(input, options);
           }, { path: [28, 0] }),
           /**
            * getInflation returns the current minting inflation value.
            */
-          getInflation: withMetadata(async function getInflation(input: cosmos_mint_v1beta1_query_pb.QueryInflationRequestJson = {}, options?: CallOptions) {
+          getInflation: withMetadata(async function getInflation(input: cosmos_mint_v1beta1_query.QueryInflationRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(28);
             return getClient(service).inflation(input, options);
           }, { path: [28, 1] }),
           /**
            * getAnnualProvisions current minting annual provisions value.
            */
-          getAnnualProvisions: withMetadata(async function getAnnualProvisions(input: cosmos_mint_v1beta1_query_pb.QueryAnnualProvisionsRequestJson = {}, options?: CallOptions) {
+          getAnnualProvisions: withMetadata(async function getAnnualProvisions(input: cosmos_mint_v1beta1_query.QueryAnnualProvisionsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(28);
             return getClient(service).annualProvisions(input, options);
           }, { path: [28, 2] }),
@@ -1254,7 +1254,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_mint_v1beta1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_mint_v1beta1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(29);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [29, 0] })
@@ -1265,21 +1265,21 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getBalance queries the number of NFTs of a given class owned by the owner, same as balanceOf in ERC721
            */
-          getBalance: withMetadata(async function getBalance(input: cosmos_nft_v1beta1_query_pb.QueryBalanceRequestJson, options?: CallOptions) {
+          getBalance: withMetadata(async function getBalance(input: cosmos_nft_v1beta1_query.QueryBalanceRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(30);
             return getClient(service).balance(input, options);
           }, { path: [30, 0] }),
           /**
            * getOwner queries the owner of the NFT based on its class and id, same as ownerOf in ERC721
            */
-          getOwner: withMetadata(async function getOwner(input: cosmos_nft_v1beta1_query_pb.QueryOwnerRequestJson, options?: CallOptions) {
+          getOwner: withMetadata(async function getOwner(input: cosmos_nft_v1beta1_query.QueryOwnerRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(30);
             return getClient(service).owner(input, options);
           }, { path: [30, 1] }),
           /**
            * getSupply queries the number of NFTs from the given class, same as totalSupply of ERC721.
            */
-          getSupply: withMetadata(async function getSupply(input: cosmos_nft_v1beta1_query_pb.QuerySupplyRequestJson, options?: CallOptions) {
+          getSupply: withMetadata(async function getSupply(input: cosmos_nft_v1beta1_query.QuerySupplyRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(30);
             return getClient(service).supply(input, options);
           }, { path: [30, 2] }),
@@ -1287,35 +1287,35 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getNFTs queries all getNFTs of a given class or owner,choose at least one of the two, similar to tokenByIndex in
            * ERC721Enumerable
            */
-          getNFTs: withMetadata(async function getNFTs(input: cosmos_nft_v1beta1_query_pb.QueryNFTsRequestJson, options?: CallOptions) {
+          getNFTs: withMetadata(async function getNFTs(input: cosmos_nft_v1beta1_query.QueryNFTsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(30);
             return getClient(service).nFTs(input, options);
           }, { path: [30, 3] }),
           /**
            * getNFT queries an getNFT based on its class and id.
            */
-          getNFT: withMetadata(async function getNFT(input: cosmos_nft_v1beta1_query_pb.QueryNFTRequestJson, options?: CallOptions) {
+          getNFT: withMetadata(async function getNFT(input: cosmos_nft_v1beta1_query.QueryNFTRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(30);
             return getClient(service).nFT(input, options);
           }, { path: [30, 4] }),
           /**
            * getClass queries an NFT class based on its id
            */
-          getClass: withMetadata(async function getClass(input: cosmos_nft_v1beta1_query_pb.QueryClassRequestJson, options?: CallOptions) {
+          getClass: withMetadata(async function getClass(input: cosmos_nft_v1beta1_query.QueryClassRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(30);
             return getClient(service).class(input, options);
           }, { path: [30, 5] }),
           /**
            * getClasses queries all NFT classes
            */
-          getClasses: withMetadata(async function getClasses(input: cosmos_nft_v1beta1_query_pb.QueryClassesRequestJson, options?: CallOptions) {
+          getClasses: withMetadata(async function getClasses(input: cosmos_nft_v1beta1_query.QueryClassesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(30);
             return getClient(service).classes(input, options);
           }, { path: [30, 6] }),
           /**
            * send defines a method to send a nft from one account to another account.
            */
-          send: withMetadata(async function send(input: cosmos_nft_v1beta1_tx_pb.MsgSendJson, options?: TxCallOptions) {
+          send: withMetadata(async function send(input: cosmos_nft_v1beta1_tx.MsgSendJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(31);
             return getMsgClient(service).send(input, options);
           }, { path: [31, 0] })
@@ -1327,14 +1327,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
             /**
              * get queries an ORM table against an unique index.
              */
-            get: withMetadata(async function get(input: cosmos_orm_query_v1alpha1_query_pb.GetRequestJson, options?: CallOptions) {
+            get: withMetadata(async function get(input: cosmos_orm_query_v1alpha1_query.GetRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(32);
               return getClient(service).get(input, options);
             }, { path: [32, 0] }),
             /**
              * getList queries an ORM table against an index.
              */
-            getList: withMetadata(async function getList(input: cosmos_orm_query_v1alpha1_query_pb.ListRequestJson, options?: CallOptions) {
+            getList: withMetadata(async function getList(input: cosmos_orm_query_v1alpha1_query.ListRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(32);
               return getClient(service).list(input, options);
             }, { path: [32, 1] })
@@ -1347,7 +1347,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getParams queries a specific parameter of a module, given its subspace and
            * key.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_params_v1beta1_query_pb.QueryParamsRequestJson, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_params_v1beta1_query.QueryParamsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(33);
             return getClient(service).params(input, options);
           }, { path: [33, 0] }),
@@ -1356,7 +1356,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getSubspaces: withMetadata(async function getSubspaces(input: cosmos_params_v1beta1_query_pb.QuerySubspacesRequestJson = {}, options?: CallOptions) {
+          getSubspaces: withMetadata(async function getSubspaces(input: cosmos_params_v1beta1_query.QuerySubspacesRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(33);
             return getClient(service).subspaces(input, options);
           }, { path: [33, 1] })
@@ -1368,7 +1368,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getFileDescriptors queries all the file descriptors in the app in order
            * to enable easier generation of dynamic clients.
            */
-          getFileDescriptors: withMetadata(async function getFileDescriptors(input: cosmos_reflection_v1_reflection_pb.FileDescriptorsRequestJson = {}, options?: CallOptions) {
+          getFileDescriptors: withMetadata(async function getFileDescriptors(input: cosmos_reflection_v1_reflection.FileDescriptorsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(34);
             return getClient(service).fileDescriptors(input, options);
           }, { path: [34, 0] })
@@ -1379,21 +1379,21 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getParams queries the parameters of slashing module
            */
-          getParams: withMetadata(async function getParams(input: cosmos_slashing_v1beta1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_slashing_v1beta1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(35);
             return getClient(service).params(input, options);
           }, { path: [35, 0] }),
           /**
            * getSigningInfo queries the signing info of given cons address
            */
-          getSigningInfo: withMetadata(async function getSigningInfo(input: cosmos_slashing_v1beta1_query_pb.QuerySigningInfoRequestJson, options?: CallOptions) {
+          getSigningInfo: withMetadata(async function getSigningInfo(input: cosmos_slashing_v1beta1_query.QuerySigningInfoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(35);
             return getClient(service).signingInfo(input, options);
           }, { path: [35, 1] }),
           /**
            * getSigningInfos queries signing info of all validators
            */
-          getSigningInfos: withMetadata(async function getSigningInfos(input: cosmos_slashing_v1beta1_query_pb.QuerySigningInfosRequestJson, options?: CallOptions) {
+          getSigningInfos: withMetadata(async function getSigningInfos(input: cosmos_slashing_v1beta1_query.QuerySigningInfosRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(35);
             return getClient(service).signingInfos(input, options);
           }, { path: [35, 2] }),
@@ -1402,7 +1402,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * them into the bonded validator set, so they can begin receiving provisions
            * and rewards again.
            */
-          unjail: withMetadata(async function unjail(input: cosmos_slashing_v1beta1_tx_pb.MsgUnjailJson, options?: TxCallOptions) {
+          unjail: withMetadata(async function unjail(input: cosmos_slashing_v1beta1_tx.MsgUnjailJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(36);
             return getMsgClient(service).unjail(input, options);
           }, { path: [36, 0] }),
@@ -1412,7 +1412,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_slashing_v1beta1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_slashing_v1beta1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(36);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [36, 1] })
@@ -1426,14 +1426,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getValidators: withMetadata(async function getValidators(input: cosmos_staking_v1beta1_query_pb.QueryValidatorsRequestJson, options?: CallOptions) {
+          getValidators: withMetadata(async function getValidators(input: cosmos_staking_v1beta1_query.QueryValidatorsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).validators(input, options);
           }, { path: [37, 0] }),
           /**
            * getValidator queries validator info for given validator address.
            */
-          getValidator: withMetadata(async function getValidator(input: cosmos_staking_v1beta1_query_pb.QueryValidatorRequestJson, options?: CallOptions) {
+          getValidator: withMetadata(async function getValidator(input: cosmos_staking_v1beta1_query.QueryValidatorRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).validator(input, options);
           }, { path: [37, 1] }),
@@ -1443,7 +1443,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getValidatorDelegations: withMetadata(async function getValidatorDelegations(input: cosmos_staking_v1beta1_query_pb.QueryValidatorDelegationsRequestJson, options?: CallOptions) {
+          getValidatorDelegations: withMetadata(async function getValidatorDelegations(input: cosmos_staking_v1beta1_query.QueryValidatorDelegationsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).validatorDelegations(input, options);
           }, { path: [37, 2] }),
@@ -1453,14 +1453,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getValidatorUnbondingDelegations: withMetadata(async function getValidatorUnbondingDelegations(input: cosmos_staking_v1beta1_query_pb.QueryValidatorUnbondingDelegationsRequestJson, options?: CallOptions) {
+          getValidatorUnbondingDelegations: withMetadata(async function getValidatorUnbondingDelegations(input: cosmos_staking_v1beta1_query.QueryValidatorUnbondingDelegationsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).validatorUnbondingDelegations(input, options);
           }, { path: [37, 3] }),
           /**
            * getDelegation queries delegate info for given validator delegator pair.
            */
-          getDelegation: withMetadata(async function getDelegation(input: cosmos_staking_v1beta1_query_pb.QueryDelegationRequestJson, options?: CallOptions) {
+          getDelegation: withMetadata(async function getDelegation(input: cosmos_staking_v1beta1_query.QueryDelegationRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).delegation(input, options);
           }, { path: [37, 4] }),
@@ -1468,7 +1468,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getUnbondingDelegation queries unbonding info for given validator delegator
            * pair.
            */
-          getUnbondingDelegation: withMetadata(async function getUnbondingDelegation(input: cosmos_staking_v1beta1_query_pb.QueryUnbondingDelegationRequestJson, options?: CallOptions) {
+          getUnbondingDelegation: withMetadata(async function getUnbondingDelegation(input: cosmos_staking_v1beta1_query.QueryUnbondingDelegationRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).unbondingDelegation(input, options);
           }, { path: [37, 5] }),
@@ -1478,7 +1478,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getDelegatorDelegations: withMetadata(async function getDelegatorDelegations(input: cosmos_staking_v1beta1_query_pb.QueryDelegatorDelegationsRequestJson, options?: CallOptions) {
+          getDelegatorDelegations: withMetadata(async function getDelegatorDelegations(input: cosmos_staking_v1beta1_query.QueryDelegatorDelegationsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).delegatorDelegations(input, options);
           }, { path: [37, 6] }),
@@ -1489,7 +1489,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getDelegatorUnbondingDelegations: withMetadata(async function getDelegatorUnbondingDelegations(input: cosmos_staking_v1beta1_query_pb.QueryDelegatorUnbondingDelegationsRequestJson, options?: CallOptions) {
+          getDelegatorUnbondingDelegations: withMetadata(async function getDelegatorUnbondingDelegations(input: cosmos_staking_v1beta1_query.QueryDelegatorUnbondingDelegationsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).delegatorUnbondingDelegations(input, options);
           }, { path: [37, 7] }),
@@ -1499,7 +1499,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getRedelegations: withMetadata(async function getRedelegations(input: cosmos_staking_v1beta1_query_pb.QueryRedelegationsRequestJson, options?: CallOptions) {
+          getRedelegations: withMetadata(async function getRedelegations(input: cosmos_staking_v1beta1_query.QueryRedelegationsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).redelegations(input, options);
           }, { path: [37, 8] }),
@@ -1510,7 +1510,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * When called from another module, this query might consume a high amount of
            * gas if the pagination field is incorrectly set.
            */
-          getDelegatorValidators: withMetadata(async function getDelegatorValidators(input: cosmos_staking_v1beta1_query_pb.QueryDelegatorValidatorsRequestJson, options?: CallOptions) {
+          getDelegatorValidators: withMetadata(async function getDelegatorValidators(input: cosmos_staking_v1beta1_query.QueryDelegatorValidatorsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).delegatorValidators(input, options);
           }, { path: [37, 9] }),
@@ -1518,98 +1518,98 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getDelegatorValidator queries validator info for given delegator validator
            * pair.
            */
-          getDelegatorValidator: withMetadata(async function getDelegatorValidator(input: cosmos_staking_v1beta1_query_pb.QueryDelegatorValidatorRequestJson, options?: CallOptions) {
+          getDelegatorValidator: withMetadata(async function getDelegatorValidator(input: cosmos_staking_v1beta1_query.QueryDelegatorValidatorRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).delegatorValidator(input, options);
           }, { path: [37, 10] }),
           /**
            * Query for individual tokenize share record information by share by id
            */
-          getTokenizeShareRecordById: withMetadata(async function getTokenizeShareRecordById(input: cosmos_staking_v1beta1_query_pb.QueryTokenizeShareRecordByIdRequestJson, options?: CallOptions) {
+          getTokenizeShareRecordById: withMetadata(async function getTokenizeShareRecordById(input: cosmos_staking_v1beta1_query.QueryTokenizeShareRecordByIdRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).tokenizeShareRecordById(input, options);
           }, { path: [37, 11] }),
           /**
            * Query for individual tokenize share record information by share denom
            */
-          getTokenizeShareRecordByDenom: withMetadata(async function getTokenizeShareRecordByDenom(input: cosmos_staking_v1beta1_query_pb.QueryTokenizeShareRecordByDenomRequestJson, options?: CallOptions) {
+          getTokenizeShareRecordByDenom: withMetadata(async function getTokenizeShareRecordByDenom(input: cosmos_staking_v1beta1_query.QueryTokenizeShareRecordByDenomRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).tokenizeShareRecordByDenom(input, options);
           }, { path: [37, 12] }),
           /**
            * Query tokenize share records by address
            */
-          getTokenizeShareRecordsOwned: withMetadata(async function getTokenizeShareRecordsOwned(input: cosmos_staking_v1beta1_query_pb.QueryTokenizeShareRecordsOwnedRequestJson, options?: CallOptions) {
+          getTokenizeShareRecordsOwned: withMetadata(async function getTokenizeShareRecordsOwned(input: cosmos_staking_v1beta1_query.QueryTokenizeShareRecordsOwnedRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).tokenizeShareRecordsOwned(input, options);
           }, { path: [37, 13] }),
           /**
            * Query for all tokenize share records
            */
-          getAllTokenizeShareRecords: withMetadata(async function getAllTokenizeShareRecords(input: cosmos_staking_v1beta1_query_pb.QueryAllTokenizeShareRecordsRequestJson, options?: CallOptions) {
+          getAllTokenizeShareRecords: withMetadata(async function getAllTokenizeShareRecords(input: cosmos_staking_v1beta1_query.QueryAllTokenizeShareRecordsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).allTokenizeShareRecords(input, options);
           }, { path: [37, 14] }),
           /**
            * Query for last tokenize share record id
            */
-          getLastTokenizeShareRecordId: withMetadata(async function getLastTokenizeShareRecordId(input: cosmos_staking_v1beta1_query_pb.QueryLastTokenizeShareRecordIdRequestJson = {}, options?: CallOptions) {
+          getLastTokenizeShareRecordId: withMetadata(async function getLastTokenizeShareRecordId(input: cosmos_staking_v1beta1_query.QueryLastTokenizeShareRecordIdRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).lastTokenizeShareRecordId(input, options);
           }, { path: [37, 15] }),
           /**
            * Query for total tokenized staked assets
            */
-          getTotalTokenizeSharedAssets: withMetadata(async function getTotalTokenizeSharedAssets(input: cosmos_staking_v1beta1_query_pb.QueryTotalTokenizeSharedAssetsRequestJson = {}, options?: CallOptions) {
+          getTotalTokenizeSharedAssets: withMetadata(async function getTotalTokenizeSharedAssets(input: cosmos_staking_v1beta1_query.QueryTotalTokenizeSharedAssetsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).totalTokenizeSharedAssets(input, options);
           }, { path: [37, 16] }),
           /**
            * Query for total liquid staked (including tokenized shares or owned by an liquid staking provider)
            */
-          getTotalLiquidStaked: withMetadata(async function getTotalLiquidStaked(input: cosmos_staking_v1beta1_query_pb.QueryTotalLiquidStakedJson = {}, options?: CallOptions) {
+          getTotalLiquidStaked: withMetadata(async function getTotalLiquidStaked(input: cosmos_staking_v1beta1_query.QueryTotalLiquidStakedJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).totalLiquidStaked(input, options);
           }, { path: [37, 17] }),
           /**
            * Query tokenize share locks
            */
-          getTokenizeShareLockInfo: withMetadata(async function getTokenizeShareLockInfo(input: cosmos_staking_v1beta1_query_pb.QueryTokenizeShareLockInfoJson, options?: CallOptions) {
+          getTokenizeShareLockInfo: withMetadata(async function getTokenizeShareLockInfo(input: cosmos_staking_v1beta1_query.QueryTokenizeShareLockInfoJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).tokenizeShareLockInfo(input, options);
           }, { path: [37, 18] }),
           /**
            * getHistoricalInfo queries the historical info for given height.
            */
-          getHistoricalInfo: withMetadata(async function getHistoricalInfo(input: cosmos_staking_v1beta1_query_pb.QueryHistoricalInfoRequestJson, options?: CallOptions) {
+          getHistoricalInfo: withMetadata(async function getHistoricalInfo(input: cosmos_staking_v1beta1_query.QueryHistoricalInfoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).historicalInfo(input, options);
           }, { path: [37, 19] }),
           /**
            * getPool queries the pool info.
            */
-          getPool: withMetadata(async function getPool(input: cosmos_staking_v1beta1_query_pb.QueryPoolRequestJson = {}, options?: CallOptions) {
+          getPool: withMetadata(async function getPool(input: cosmos_staking_v1beta1_query.QueryPoolRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).pool(input, options);
           }, { path: [37, 20] }),
           /**
            * Parameters queries the staking parameters.
            */
-          getParams: withMetadata(async function getParams(input: cosmos_staking_v1beta1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: cosmos_staking_v1beta1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(37);
             return getClient(service).params(input, options);
           }, { path: [37, 21] }),
           /**
            * createValidator defines a method for creating a new validator.
            */
-          createValidator: withMetadata(async function createValidator(input: cosmos_staking_v1beta1_tx_pb.MsgCreateValidatorJson, options?: TxCallOptions) {
+          createValidator: withMetadata(async function createValidator(input: cosmos_staking_v1beta1_tx.MsgCreateValidatorJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).createValidator(input, options);
           }, { path: [38, 0] }),
           /**
            * editValidator defines a method for editing an existing validator.
            */
-          editValidator: withMetadata(async function editValidator(input: cosmos_staking_v1beta1_tx_pb.MsgEditValidatorJson, options?: TxCallOptions) {
+          editValidator: withMetadata(async function editValidator(input: cosmos_staking_v1beta1_tx.MsgEditValidatorJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).editValidator(input, options);
           }, { path: [38, 1] }),
@@ -1617,7 +1617,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * delegate defines a method for performing a delegation of coins
            * from a delegator to a validator.
            */
-          delegate: withMetadata(async function delegate(input: cosmos_staking_v1beta1_tx_pb.MsgDelegateJson, options?: TxCallOptions) {
+          delegate: withMetadata(async function delegate(input: cosmos_staking_v1beta1_tx.MsgDelegateJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).delegate(input, options);
           }, { path: [38, 2] }),
@@ -1625,7 +1625,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * beginRedelegate defines a method for performing a redelegation
            * of coins from a delegator and source validator to a destination validator.
            */
-          beginRedelegate: withMetadata(async function beginRedelegate(input: cosmos_staking_v1beta1_tx_pb.MsgBeginRedelegateJson, options?: TxCallOptions) {
+          beginRedelegate: withMetadata(async function beginRedelegate(input: cosmos_staking_v1beta1_tx.MsgBeginRedelegateJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).beginRedelegate(input, options);
           }, { path: [38, 3] }),
@@ -1633,7 +1633,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * undelegate defines a method for performing an undelegation from a
            * delegate and a validator.
            */
-          undelegate: withMetadata(async function undelegate(input: cosmos_staking_v1beta1_tx_pb.MsgUndelegateJson, options?: TxCallOptions) {
+          undelegate: withMetadata(async function undelegate(input: cosmos_staking_v1beta1_tx.MsgUndelegateJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).undelegate(input, options);
           }, { path: [38, 4] }),
@@ -1643,7 +1643,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          cancelUnbondingDelegation: withMetadata(async function cancelUnbondingDelegation(input: cosmos_staking_v1beta1_tx_pb.MsgCancelUnbondingDelegationJson, options?: TxCallOptions) {
+          cancelUnbondingDelegation: withMetadata(async function cancelUnbondingDelegation(input: cosmos_staking_v1beta1_tx.MsgCancelUnbondingDelegationJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).cancelUnbondingDelegation(input, options);
           }, { path: [38, 5] }),
@@ -1652,7 +1652,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * parameters.
            * Since: cosmos-sdk 0.47
            */
-          updateParams: withMetadata(async function updateParams(input: cosmos_staking_v1beta1_tx_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: cosmos_staking_v1beta1_tx.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [38, 6] }),
@@ -1662,14 +1662,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * This allows a validator to stop their services and jail themselves without
            * experiencing a slash
            */
-          unbondValidator: withMetadata(async function unbondValidator(input: cosmos_staking_v1beta1_tx_pb.MsgUnbondValidatorJson, options?: TxCallOptions) {
+          unbondValidator: withMetadata(async function unbondValidator(input: cosmos_staking_v1beta1_tx.MsgUnbondValidatorJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).unbondValidator(input, options);
           }, { path: [38, 7] }),
           /**
            * tokenizeShares defines a method for tokenizing shares from a validator.
            */
-          tokenizeShares: withMetadata(async function tokenizeShares(input: cosmos_staking_v1beta1_tx_pb.MsgTokenizeSharesJson, options?: TxCallOptions) {
+          tokenizeShares: withMetadata(async function tokenizeShares(input: cosmos_staking_v1beta1_tx.MsgTokenizeSharesJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).tokenizeShares(input, options);
           }, { path: [38, 8] }),
@@ -1677,7 +1677,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * redeemTokensForShares defines a method for redeeming tokens from a validator for
            * shares.
            */
-          redeemTokensForShares: withMetadata(async function redeemTokensForShares(input: cosmos_staking_v1beta1_tx_pb.MsgRedeemTokensForSharesJson, options?: TxCallOptions) {
+          redeemTokensForShares: withMetadata(async function redeemTokensForShares(input: cosmos_staking_v1beta1_tx.MsgRedeemTokensForSharesJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).redeemTokensForShares(input, options);
           }, { path: [38, 9] }),
@@ -1685,14 +1685,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * transferTokenizeShareRecord defines a method to transfer ownership of
            * TokenizeShareRecord
            */
-          transferTokenizeShareRecord: withMetadata(async function transferTokenizeShareRecord(input: cosmos_staking_v1beta1_tx_pb.MsgTransferTokenizeShareRecordJson, options?: TxCallOptions) {
+          transferTokenizeShareRecord: withMetadata(async function transferTokenizeShareRecord(input: cosmos_staking_v1beta1_tx.MsgTransferTokenizeShareRecordJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).transferTokenizeShareRecord(input, options);
           }, { path: [38, 10] }),
           /**
            * disableTokenizeShares defines a method to prevent the tokenization of an addresses stake
            */
-          disableTokenizeShares: withMetadata(async function disableTokenizeShares(input: cosmos_staking_v1beta1_tx_pb.MsgDisableTokenizeSharesJson, options?: TxCallOptions) {
+          disableTokenizeShares: withMetadata(async function disableTokenizeShares(input: cosmos_staking_v1beta1_tx.MsgDisableTokenizeSharesJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).disableTokenizeShares(input, options);
           }, { path: [38, 11] }),
@@ -1700,14 +1700,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * enableTokenizeShares defines a method to re-enable the tokenization of an addresseses stake
            * after it has been disabled
            */
-          enableTokenizeShares: withMetadata(async function enableTokenizeShares(input: cosmos_staking_v1beta1_tx_pb.MsgEnableTokenizeSharesJson, options?: TxCallOptions) {
+          enableTokenizeShares: withMetadata(async function enableTokenizeShares(input: cosmos_staking_v1beta1_tx.MsgEnableTokenizeSharesJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).enableTokenizeShares(input, options);
           }, { path: [38, 12] }),
           /**
            * validatorBond defines a method for performing a validator self-bond
            */
-          validatorBond: withMetadata(async function validatorBond(input: cosmos_staking_v1beta1_tx_pb.MsgValidatorBondJson, options?: TxCallOptions) {
+          validatorBond: withMetadata(async function validatorBond(input: cosmos_staking_v1beta1_tx.MsgValidatorBondJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(38);
             return getMsgClient(service).validatorBond(input, options);
           }, { path: [38, 13] })
@@ -1718,28 +1718,28 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getSimulate simulates executing a transaction for estimating gas usage.
            */
-          getSimulate: withMetadata(async function getSimulate(input: cosmos_tx_v1beta1_service_pb.SimulateRequestJson, options?: CallOptions) {
+          getSimulate: withMetadata(async function getSimulate(input: cosmos_tx_v1beta1_service.SimulateRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).simulate(input, options);
           }, { path: [39, 0] }),
           /**
            * getTx fetches a tx by hash.
            */
-          getTx: withMetadata(async function getTx(input: cosmos_tx_v1beta1_service_pb.GetTxRequestJson, options?: CallOptions) {
+          getTx: withMetadata(async function getTx(input: cosmos_tx_v1beta1_service.GetTxRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).getTx(input, options);
           }, { path: [39, 1] }),
           /**
            * getBroadcastTx broadcast transaction.
            */
-          getBroadcastTx: withMetadata(async function getBroadcastTx(input: cosmos_tx_v1beta1_service_pb.BroadcastTxRequestJson, options?: CallOptions) {
+          getBroadcastTx: withMetadata(async function getBroadcastTx(input: cosmos_tx_v1beta1_service.BroadcastTxRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).broadcastTx(input, options);
           }, { path: [39, 2] }),
           /**
            * getTxsEvent fetches txs by event.
            */
-          getTxsEvent: withMetadata(async function getTxsEvent(input: cosmos_tx_v1beta1_service_pb.GetTxsEventRequestJson, options?: CallOptions) {
+          getTxsEvent: withMetadata(async function getTxsEvent(input: cosmos_tx_v1beta1_service.GetTxsEventRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).getTxsEvent(input, options);
           }, { path: [39, 3] }),
@@ -1748,7 +1748,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.45.2
            */
-          getBlockWithTxs: withMetadata(async function getBlockWithTxs(input: cosmos_tx_v1beta1_service_pb.GetBlockWithTxsRequestJson, options?: CallOptions) {
+          getBlockWithTxs: withMetadata(async function getBlockWithTxs(input: cosmos_tx_v1beta1_service.GetBlockWithTxsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).getBlockWithTxs(input, options);
           }, { path: [39, 4] }),
@@ -1757,7 +1757,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          getTxDecode: withMetadata(async function getTxDecode(input: cosmos_tx_v1beta1_service_pb.TxDecodeRequestJson, options?: CallOptions) {
+          getTxDecode: withMetadata(async function getTxDecode(input: cosmos_tx_v1beta1_service.TxDecodeRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).txDecode(input, options);
           }, { path: [39, 5] }),
@@ -1766,7 +1766,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          getTxEncode: withMetadata(async function getTxEncode(input: cosmos_tx_v1beta1_service_pb.TxEncodeRequestJson, options?: CallOptions) {
+          getTxEncode: withMetadata(async function getTxEncode(input: cosmos_tx_v1beta1_service.TxEncodeRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).txEncode(input, options);
           }, { path: [39, 6] }),
@@ -1775,7 +1775,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          getTxEncodeAmino: withMetadata(async function getTxEncodeAmino(input: cosmos_tx_v1beta1_service_pb.TxEncodeAminoRequestJson, options?: CallOptions) {
+          getTxEncodeAmino: withMetadata(async function getTxEncodeAmino(input: cosmos_tx_v1beta1_service.TxEncodeAminoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).txEncodeAmino(input, options);
           }, { path: [39, 7] }),
@@ -1784,7 +1784,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.47
            */
-          getTxDecodeAmino: withMetadata(async function getTxDecodeAmino(input: cosmos_tx_v1beta1_service_pb.TxDecodeAminoRequestJson, options?: CallOptions) {
+          getTxDecodeAmino: withMetadata(async function getTxDecodeAmino(input: cosmos_tx_v1beta1_service.TxDecodeAminoRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(39);
             return getClient(service).txDecodeAmino(input, options);
           }, { path: [39, 8] })
@@ -1795,14 +1795,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getCurrentPlan queries the current upgrade plan.
            */
-          getCurrentPlan: withMetadata(async function getCurrentPlan(input: cosmos_upgrade_v1beta1_query_pb.QueryCurrentPlanRequestJson = {}, options?: CallOptions) {
+          getCurrentPlan: withMetadata(async function getCurrentPlan(input: cosmos_upgrade_v1beta1_query.QueryCurrentPlanRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(40);
             return getClient(service).currentPlan(input, options);
           }, { path: [40, 0] }),
           /**
            * getAppliedPlan queries a previously applied upgrade plan by its name.
            */
-          getAppliedPlan: withMetadata(async function getAppliedPlan(input: cosmos_upgrade_v1beta1_query_pb.QueryAppliedPlanRequestJson, options?: CallOptions) {
+          getAppliedPlan: withMetadata(async function getAppliedPlan(input: cosmos_upgrade_v1beta1_query.QueryAppliedPlanRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(40);
             return getClient(service).appliedPlan(input, options);
           }, { path: [40, 1] }),
@@ -1815,7 +1815,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * (https://github.com/cosmos/ibc-go/blob/2c880a22e9f9cc75f62b527ca94aa75ce1106001/proto/ibc/core/client/v1/query.proto#L54)
            * @deprecated
            */
-          getUpgradedConsensusState: withMetadata(async function getUpgradedConsensusState(input: cosmos_upgrade_v1beta1_query_pb.QueryUpgradedConsensusStateRequestJson, options?: CallOptions) {
+          getUpgradedConsensusState: withMetadata(async function getUpgradedConsensusState(input: cosmos_upgrade_v1beta1_query.QueryUpgradedConsensusStateRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(40);
             return getClient(service).upgradedConsensusState(input, options);
           }, { path: [40, 2] }),
@@ -1824,7 +1824,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.43
            */
-          getModuleVersions: withMetadata(async function getModuleVersions(input: cosmos_upgrade_v1beta1_query_pb.QueryModuleVersionsRequestJson, options?: CallOptions) {
+          getModuleVersions: withMetadata(async function getModuleVersions(input: cosmos_upgrade_v1beta1_query.QueryModuleVersionsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(40);
             return getClient(service).moduleVersions(input, options);
           }, { path: [40, 3] }),
@@ -1833,7 +1833,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          getAuthority: withMetadata(async function getAuthority(input: cosmos_upgrade_v1beta1_query_pb.QueryAuthorityRequestJson = {}, options?: CallOptions) {
+          getAuthority: withMetadata(async function getAuthority(input: cosmos_upgrade_v1beta1_query.QueryAuthorityRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(40);
             return getClient(service).authority(input, options);
           }, { path: [40, 4] }),
@@ -1842,7 +1842,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          softwareUpgrade: withMetadata(async function softwareUpgrade(input: cosmos_upgrade_v1beta1_tx_pb.MsgSoftwareUpgradeJson, options?: TxCallOptions) {
+          softwareUpgrade: withMetadata(async function softwareUpgrade(input: cosmos_upgrade_v1beta1_tx.MsgSoftwareUpgradeJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(41);
             return getMsgClient(service).softwareUpgrade(input, options);
           }, { path: [41, 0] }),
@@ -1852,7 +1852,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          cancelUpgrade: withMetadata(async function cancelUpgrade(input: cosmos_upgrade_v1beta1_tx_pb.MsgCancelUpgradeJson, options?: TxCallOptions) {
+          cancelUpgrade: withMetadata(async function cancelUpgrade(input: cosmos_upgrade_v1beta1_tx.MsgCancelUpgradeJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(41);
             return getMsgClient(service).cancelUpgrade(input, options);
           }, { path: [41, 1] })
@@ -1864,7 +1864,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * createVestingAccount defines a method that enables creating a vesting
            * account.
            */
-          createVestingAccount: withMetadata(async function createVestingAccount(input: cosmos_vesting_v1beta1_tx_pb.MsgCreateVestingAccountJson, options?: TxCallOptions) {
+          createVestingAccount: withMetadata(async function createVestingAccount(input: cosmos_vesting_v1beta1_tx.MsgCreateVestingAccountJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(42);
             return getMsgClient(service).createVestingAccount(input, options);
           }, { path: [42, 0] }),
@@ -1874,7 +1874,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          createPermanentLockedAccount: withMetadata(async function createPermanentLockedAccount(input: cosmos_vesting_v1beta1_tx_pb.MsgCreatePermanentLockedAccountJson, options?: TxCallOptions) {
+          createPermanentLockedAccount: withMetadata(async function createPermanentLockedAccount(input: cosmos_vesting_v1beta1_tx.MsgCreatePermanentLockedAccountJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(42);
             return getMsgClient(service).createPermanentLockedAccount(input, options);
           }, { path: [42, 1] }),
@@ -1884,7 +1884,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: cosmos-sdk 0.46
            */
-          createPeriodicVestingAccount: withMetadata(async function createPeriodicVestingAccount(input: cosmos_vesting_v1beta1_tx_pb.MsgCreatePeriodicVestingAccountJson, options?: TxCallOptions) {
+          createPeriodicVestingAccount: withMetadata(async function createPeriodicVestingAccount(input: cosmos_vesting_v1beta1_tx.MsgCreatePeriodicVestingAccountJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(42);
             return getMsgClient(service).createPeriodicVestingAccount(input, options);
           }, { path: [42, 2] })
@@ -1893,67 +1893,67 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
     },
     tendermint: {
       abci: {
-        getEcho: withMetadata(async function getEcho(input: tendermint_abci_types_pb.RequestEchoJson, options?: CallOptions) {
+        getEcho: withMetadata(async function getEcho(input: tendermint_abci_types.RequestEchoJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).echo(input, options);
         }, { path: [8, 0] }),
-        getFlush: withMetadata(async function getFlush(input: tendermint_abci_types_pb.RequestFlushJson = {}, options?: CallOptions) {
+        getFlush: withMetadata(async function getFlush(input: tendermint_abci_types.RequestFlushJson = {}, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).flush(input, options);
         }, { path: [8, 1] }),
-        getInfo: withMetadata(async function getInfo(input: tendermint_abci_types_pb.RequestInfoJson, options?: CallOptions) {
+        getInfo: withMetadata(async function getInfo(input: tendermint_abci_types.RequestInfoJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).info(input, options);
         }, { path: [8, 2] }),
-        getDeliverTx: withMetadata(async function getDeliverTx(input: tendermint_abci_types_pb.RequestDeliverTxJson, options?: CallOptions) {
+        getDeliverTx: withMetadata(async function getDeliverTx(input: tendermint_abci_types.RequestDeliverTxJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).deliverTx(input, options);
         }, { path: [8, 3] }),
-        getCheckTx: withMetadata(async function getCheckTx(input: tendermint_abci_types_pb.RequestCheckTxJson, options?: CallOptions) {
+        getCheckTx: withMetadata(async function getCheckTx(input: tendermint_abci_types.RequestCheckTxJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).checkTx(input, options);
         }, { path: [8, 4] }),
-        getQuery: withMetadata(async function getQuery(input: tendermint_abci_types_pb.RequestQueryJson, options?: CallOptions) {
+        getQuery: withMetadata(async function getQuery(input: tendermint_abci_types.RequestQueryJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).query(input, options);
         }, { path: [8, 5] }),
-        getCommit: withMetadata(async function getCommit(input: tendermint_abci_types_pb.RequestCommitJson = {}, options?: CallOptions) {
+        getCommit: withMetadata(async function getCommit(input: tendermint_abci_types.RequestCommitJson = {}, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).commit(input, options);
         }, { path: [8, 6] }),
-        getInitChain: withMetadata(async function getInitChain(input: tendermint_abci_types_pb.RequestInitChainJson, options?: CallOptions) {
+        getInitChain: withMetadata(async function getInitChain(input: tendermint_abci_types.RequestInitChainJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).initChain(input, options);
         }, { path: [8, 7] }),
-        getBeginBlock: withMetadata(async function getBeginBlock(input: tendermint_abci_types_pb.RequestBeginBlockJson, options?: CallOptions) {
+        getBeginBlock: withMetadata(async function getBeginBlock(input: tendermint_abci_types.RequestBeginBlockJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).beginBlock(input, options);
         }, { path: [8, 8] }),
-        getEndBlock: withMetadata(async function getEndBlock(input: tendermint_abci_types_pb.RequestEndBlockJson, options?: CallOptions) {
+        getEndBlock: withMetadata(async function getEndBlock(input: tendermint_abci_types.RequestEndBlockJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).endBlock(input, options);
         }, { path: [8, 9] }),
-        getListSnapshots: withMetadata(async function getListSnapshots(input: tendermint_abci_types_pb.RequestListSnapshotsJson = {}, options?: CallOptions) {
+        getListSnapshots: withMetadata(async function getListSnapshots(input: tendermint_abci_types.RequestListSnapshotsJson = {}, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).listSnapshots(input, options);
         }, { path: [8, 10] }),
-        getOfferSnapshot: withMetadata(async function getOfferSnapshot(input: tendermint_abci_types_pb.RequestOfferSnapshotJson, options?: CallOptions) {
+        getOfferSnapshot: withMetadata(async function getOfferSnapshot(input: tendermint_abci_types.RequestOfferSnapshotJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).offerSnapshot(input, options);
         }, { path: [8, 11] }),
-        getLoadSnapshotChunk: withMetadata(async function getLoadSnapshotChunk(input: tendermint_abci_types_pb.RequestLoadSnapshotChunkJson, options?: CallOptions) {
+        getLoadSnapshotChunk: withMetadata(async function getLoadSnapshotChunk(input: tendermint_abci_types.RequestLoadSnapshotChunkJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).loadSnapshotChunk(input, options);
         }, { path: [8, 12] }),
-        getApplySnapshotChunk: withMetadata(async function getApplySnapshotChunk(input: tendermint_abci_types_pb.RequestApplySnapshotChunkJson, options?: CallOptions) {
+        getApplySnapshotChunk: withMetadata(async function getApplySnapshotChunk(input: tendermint_abci_types.RequestApplySnapshotChunkJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).applySnapshotChunk(input, options);
         }, { path: [8, 13] }),
-        getPrepareProposal: withMetadata(async function getPrepareProposal(input: tendermint_abci_types_pb.RequestPrepareProposalJson, options?: CallOptions) {
+        getPrepareProposal: withMetadata(async function getPrepareProposal(input: tendermint_abci_types.RequestPrepareProposalJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).prepareProposal(input, options);
         }, { path: [8, 14] }),
-        getProcessProposal: withMetadata(async function getProcessProposal(input: tendermint_abci_types_pb.RequestProcessProposalJson, options?: CallOptions) {
+        getProcessProposal: withMetadata(async function getProcessProposal(input: tendermint_abci_types.RequestProcessProposalJson, options?: CallOptions) {
           const service = await serviceLoader.loadAt(8);
           return getClient(service).processProposal(input, options);
         }, { path: [8, 15] })

--- a/ts/src/generated/createNodeSDK.ts
+++ b/ts/src/generated/createNodeSDK.ts
@@ -1,23 +1,23 @@
-import type * as akash_audit_v1_query_pb from "./protos/akash/audit/v1/query_pb.ts";
-import type * as akash_audit_v1_msg_pb from "./protos/akash/audit/v1/msg_pb.ts";
-import type * as akash_cert_v1_query_pb from "./protos/akash/cert/v1/query_pb.ts";
-import type * as akash_cert_v1_msg_pb from "./protos/akash/cert/v1/msg_pb.ts";
-import type * as akash_deployment_v1beta4_query_pb from "./protos/akash/deployment/v1beta4/query_pb.ts";
-import type * as akash_deployment_v1beta4_deploymentmsg_pb from "./protos/akash/deployment/v1beta4/deploymentmsg_pb.ts";
-import type * as akash_deployment_v1_msg_pb from "./protos/akash/deployment/v1/msg_pb.ts";
-import type * as akash_deployment_v1beta4_groupmsg_pb from "./protos/akash/deployment/v1beta4/groupmsg_pb.ts";
-import type * as akash_deployment_v1beta4_paramsmsg_pb from "./protos/akash/deployment/v1beta4/paramsmsg_pb.ts";
-import type * as akash_escrow_v1_query_pb from "./protos/akash/escrow/v1/query_pb.ts";
-import type * as akash_market_v1beta5_query_pb from "./protos/akash/market/v1beta5/query_pb.ts";
-import type * as akash_market_v1beta5_bidmsg_pb from "./protos/akash/market/v1beta5/bidmsg_pb.ts";
-import type * as akash_market_v1beta5_leasemsg_pb from "./protos/akash/market/v1beta5/leasemsg_pb.ts";
-import type * as akash_market_v1beta5_paramsmsg_pb from "./protos/akash/market/v1beta5/paramsmsg_pb.ts";
-import type * as akash_provider_v1beta4_query_pb from "./protos/akash/provider/v1beta4/query_pb.ts";
-import type * as akash_provider_v1beta4_msg_pb from "./protos/akash/provider/v1beta4/msg_pb.ts";
-import type * as akash_staking_v1beta3_query_pb from "./protos/akash/staking/v1beta3/query_pb.ts";
-import type * as akash_staking_v1beta3_paramsmsg_pb from "./protos/akash/staking/v1beta3/paramsmsg_pb.ts";
-import type * as akash_take_v1_query_pb from "./protos/akash/take/v1/query_pb.ts";
-import type * as akash_take_v1_paramsmsg_pb from "./protos/akash/take/v1/paramsmsg_pb.ts";
+import type * as akash_audit_v1_query from "./protos/akash/audit/v1/query_pb.ts";
+import type * as akash_audit_v1_msg from "./protos/akash/audit/v1/msg_pb.ts";
+import type * as akash_cert_v1_query from "./protos/akash/cert/v1/query_pb.ts";
+import type * as akash_cert_v1_msg from "./protos/akash/cert/v1/msg_pb.ts";
+import type * as akash_deployment_v1beta4_query from "./protos/akash/deployment/v1beta4/query_pb.ts";
+import type * as akash_deployment_v1beta4_deploymentmsg from "./protos/akash/deployment/v1beta4/deploymentmsg_pb.ts";
+import type * as akash_deployment_v1_msg from "./protos/akash/deployment/v1/msg_pb.ts";
+import type * as akash_deployment_v1beta4_groupmsg from "./protos/akash/deployment/v1beta4/groupmsg_pb.ts";
+import type * as akash_deployment_v1beta4_paramsmsg from "./protos/akash/deployment/v1beta4/paramsmsg_pb.ts";
+import type * as akash_escrow_v1_query from "./protos/akash/escrow/v1/query_pb.ts";
+import type * as akash_market_v1beta5_query from "./protos/akash/market/v1beta5/query_pb.ts";
+import type * as akash_market_v1beta5_bidmsg from "./protos/akash/market/v1beta5/bidmsg_pb.ts";
+import type * as akash_market_v1beta5_leasemsg from "./protos/akash/market/v1beta5/leasemsg_pb.ts";
+import type * as akash_market_v1beta5_paramsmsg from "./protos/akash/market/v1beta5/paramsmsg_pb.ts";
+import type * as akash_provider_v1beta4_query from "./protos/akash/provider/v1beta4/query_pb.ts";
+import type * as akash_provider_v1beta4_msg from "./protos/akash/provider/v1beta4/msg_pb.ts";
+import type * as akash_staking_v1beta3_query from "./protos/akash/staking/v1beta3/query_pb.ts";
+import type * as akash_staking_v1beta3_paramsmsg from "./protos/akash/staking/v1beta3/paramsmsg_pb.ts";
+import type * as akash_take_v1_query from "./protos/akash/take/v1/query_pb.ts";
+import type * as akash_take_v1_paramsmsg from "./protos/akash/take/v1/paramsmsg_pb.ts";
 import { createClientFactory } from "../client/createClientFactory.ts";
 import type { Transport, CallOptions, TxCallOptions } from "../transport/types.ts";
 import type { SDKOptions } from "../sdk/types.ts";
@@ -52,42 +52,42 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getAllProvidersAttributes queries all providers.
            */
-          getAllProvidersAttributes: withMetadata(async function getAllProvidersAttributes(input: akash_audit_v1_query_pb.QueryAllProvidersAttributesRequestJson, options?: CallOptions) {
+          getAllProvidersAttributes: withMetadata(async function getAllProvidersAttributes(input: akash_audit_v1_query.QueryAllProvidersAttributesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(0);
             return getClient(service).allProvidersAttributes(input, options);
           }, { path: [0, 0] }),
           /**
            * getProviderAttributes queries all provider signed attributes.
            */
-          getProviderAttributes: withMetadata(async function getProviderAttributes(input: akash_audit_v1_query_pb.QueryProviderAttributesRequestJson, options?: CallOptions) {
+          getProviderAttributes: withMetadata(async function getProviderAttributes(input: akash_audit_v1_query.QueryProviderAttributesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(0);
             return getClient(service).providerAttributes(input, options);
           }, { path: [0, 1] }),
           /**
            * getProviderAuditorAttributes queries provider signed attributes by specific auditor.
            */
-          getProviderAuditorAttributes: withMetadata(async function getProviderAuditorAttributes(input: akash_audit_v1_query_pb.QueryProviderAuditorRequestJson, options?: CallOptions) {
+          getProviderAuditorAttributes: withMetadata(async function getProviderAuditorAttributes(input: akash_audit_v1_query.QueryProviderAuditorRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(0);
             return getClient(service).providerAuditorAttributes(input, options);
           }, { path: [0, 2] }),
           /**
            * getAuditorAttributes queries all providers signed by this auditor.
            */
-          getAuditorAttributes: withMetadata(async function getAuditorAttributes(input: akash_audit_v1_query_pb.QueryAuditorAttributesRequestJson, options?: CallOptions) {
+          getAuditorAttributes: withMetadata(async function getAuditorAttributes(input: akash_audit_v1_query.QueryAuditorAttributesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(0);
             return getClient(service).auditorAttributes(input, options);
           }, { path: [0, 3] }),
           /**
            * signProviderAttributes defines a method that signs provider attributes.
            */
-          signProviderAttributes: withMetadata(async function signProviderAttributes(input: akash_audit_v1_msg_pb.MsgSignProviderAttributesJson, options?: TxCallOptions) {
+          signProviderAttributes: withMetadata(async function signProviderAttributes(input: akash_audit_v1_msg.MsgSignProviderAttributesJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getMsgClient(service).signProviderAttributes(input, options);
           }, { path: [1, 0] }),
           /**
            * deleteProviderAttributes defines a method that deletes provider attributes.
            */
-          deleteProviderAttributes: withMetadata(async function deleteProviderAttributes(input: akash_audit_v1_msg_pb.MsgDeleteProviderAttributesJson, options?: TxCallOptions) {
+          deleteProviderAttributes: withMetadata(async function deleteProviderAttributes(input: akash_audit_v1_msg.MsgDeleteProviderAttributesJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getMsgClient(service).deleteProviderAttributes(input, options);
           }, { path: [1, 1] })
@@ -98,21 +98,21 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getCertificates queries certificates on-chain.
            */
-          getCertificates: withMetadata(async function getCertificates(input: akash_cert_v1_query_pb.QueryCertificatesRequestJson, options?: CallOptions) {
+          getCertificates: withMetadata(async function getCertificates(input: akash_cert_v1_query.QueryCertificatesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(2);
             return getClient(service).certificates(input, options);
           }, { path: [2, 0] }),
           /**
            * createCertificate defines a method to create new certificate given proper inputs.
            */
-          createCertificate: withMetadata(async function createCertificate(input: akash_cert_v1_msg_pb.MsgCreateCertificateJson, options?: TxCallOptions) {
+          createCertificate: withMetadata(async function createCertificate(input: akash_cert_v1_msg.MsgCreateCertificateJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(3);
             return getMsgClient(service).createCertificate(input, options);
           }, { path: [3, 0] }),
           /**
            * revokeCertificate defines a method to revoke the certificate.
            */
-          revokeCertificate: withMetadata(async function revokeCertificate(input: akash_cert_v1_msg_pb.MsgRevokeCertificateJson, options?: TxCallOptions) {
+          revokeCertificate: withMetadata(async function revokeCertificate(input: akash_cert_v1_msg.MsgRevokeCertificateJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(3);
             return getMsgClient(service).revokeCertificate(input, options);
           }, { path: [3, 1] })
@@ -123,77 +123,77 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getDeployments queries deployments.
            */
-          getDeployments: withMetadata(async function getDeployments(input: akash_deployment_v1beta4_query_pb.QueryDeploymentsRequestJson, options?: CallOptions) {
+          getDeployments: withMetadata(async function getDeployments(input: akash_deployment_v1beta4_query.QueryDeploymentsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(4);
             return getClient(service).deployments(input, options);
           }, { path: [4, 0] }),
           /**
            * getDeployment queries deployment details.
            */
-          getDeployment: withMetadata(async function getDeployment(input: akash_deployment_v1beta4_query_pb.QueryDeploymentRequestJson, options?: CallOptions) {
+          getDeployment: withMetadata(async function getDeployment(input: akash_deployment_v1beta4_query.QueryDeploymentRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(4);
             return getClient(service).deployment(input, options);
           }, { path: [4, 1] }),
           /**
            * getGroup queries group details.
            */
-          getGroup: withMetadata(async function getGroup(input: akash_deployment_v1beta4_query_pb.QueryGroupRequestJson, options?: CallOptions) {
+          getGroup: withMetadata(async function getGroup(input: akash_deployment_v1beta4_query.QueryGroupRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(4);
             return getClient(service).group(input, options);
           }, { path: [4, 2] }),
           /**
            * getParams returns the total set of minting parameters.
            */
-          getParams: withMetadata(async function getParams(input: akash_deployment_v1beta4_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: akash_deployment_v1beta4_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(4);
             return getClient(service).params(input, options);
           }, { path: [4, 3] }),
           /**
            * createDeployment defines a method to create new deployment given proper inputs.
            */
-          createDeployment: withMetadata(async function createDeployment(input: akash_deployment_v1beta4_deploymentmsg_pb.MsgCreateDeploymentJson, options?: TxCallOptions) {
+          createDeployment: withMetadata(async function createDeployment(input: akash_deployment_v1beta4_deploymentmsg.MsgCreateDeploymentJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).createDeployment(input, options);
           }, { path: [5, 0] }),
           /**
            * depositDeployment deposits more funds into the deployment account.
            */
-          depositDeployment: withMetadata(async function depositDeployment(input: akash_deployment_v1_msg_pb.MsgDepositDeploymentJson, options?: TxCallOptions) {
+          depositDeployment: withMetadata(async function depositDeployment(input: akash_deployment_v1_msg.MsgDepositDeploymentJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).depositDeployment(input, options);
           }, { path: [5, 1] }),
           /**
            * updateDeployment defines a method to update a deployment given proper inputs.
            */
-          updateDeployment: withMetadata(async function updateDeployment(input: akash_deployment_v1beta4_deploymentmsg_pb.MsgUpdateDeploymentJson, options?: TxCallOptions) {
+          updateDeployment: withMetadata(async function updateDeployment(input: akash_deployment_v1beta4_deploymentmsg.MsgUpdateDeploymentJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).updateDeployment(input, options);
           }, { path: [5, 2] }),
           /**
            * closeDeployment defines a method to close a deployment given proper inputs.
            */
-          closeDeployment: withMetadata(async function closeDeployment(input: akash_deployment_v1beta4_deploymentmsg_pb.MsgCloseDeploymentJson, options?: TxCallOptions) {
+          closeDeployment: withMetadata(async function closeDeployment(input: akash_deployment_v1beta4_deploymentmsg.MsgCloseDeploymentJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).closeDeployment(input, options);
           }, { path: [5, 3] }),
           /**
            * closeGroup defines a method to close a group of a deployment given proper inputs.
            */
-          closeGroup: withMetadata(async function closeGroup(input: akash_deployment_v1beta4_groupmsg_pb.MsgCloseGroupJson, options?: TxCallOptions) {
+          closeGroup: withMetadata(async function closeGroup(input: akash_deployment_v1beta4_groupmsg.MsgCloseGroupJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).closeGroup(input, options);
           }, { path: [5, 4] }),
           /**
            * pauseGroup defines a method to close a group of a deployment given proper inputs.
            */
-          pauseGroup: withMetadata(async function pauseGroup(input: akash_deployment_v1beta4_groupmsg_pb.MsgPauseGroupJson, options?: TxCallOptions) {
+          pauseGroup: withMetadata(async function pauseGroup(input: akash_deployment_v1beta4_groupmsg.MsgPauseGroupJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).pauseGroup(input, options);
           }, { path: [5, 5] }),
           /**
            * startGroup defines a method to close a group of a deployment given proper inputs.
            */
-          startGroup: withMetadata(async function startGroup(input: akash_deployment_v1beta4_groupmsg_pb.MsgStartGroupJson, options?: TxCallOptions) {
+          startGroup: withMetadata(async function startGroup(input: akash_deployment_v1beta4_groupmsg.MsgStartGroupJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).startGroup(input, options);
           }, { path: [5, 6] }),
@@ -203,7 +203,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: akash v1.0.0
            */
-          updateParams: withMetadata(async function updateParams(input: akash_deployment_v1beta4_paramsmsg_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: akash_deployment_v1beta4_paramsmsg.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(5);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [5, 7] })
@@ -214,14 +214,14 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getAccounts queries all accounts.
            */
-          getAccounts: withMetadata(async function getAccounts(input: akash_escrow_v1_query_pb.QueryAccountsRequestJson, options?: CallOptions) {
+          getAccounts: withMetadata(async function getAccounts(input: akash_escrow_v1_query.QueryAccountsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).accounts(input, options);
           }, { path: [6, 0] }),
           /**
            * getPayments queries all payments.
            */
-          getPayments: withMetadata(async function getPayments(input: akash_escrow_v1_query_pb.QueryPaymentsRequestJson, options?: CallOptions) {
+          getPayments: withMetadata(async function getPayments(input: akash_escrow_v1_query.QueryPaymentsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(6);
             return getClient(service).payments(input, options);
           }, { path: [6, 1] })
@@ -232,84 +232,84 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getOrders queries orders with filters.
            */
-          getOrders: withMetadata(async function getOrders(input: akash_market_v1beta5_query_pb.QueryOrdersRequestJson, options?: CallOptions) {
+          getOrders: withMetadata(async function getOrders(input: akash_market_v1beta5_query.QueryOrdersRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getClient(service).orders(input, options);
           }, { path: [7, 0] }),
           /**
            * getOrder queries order details.
            */
-          getOrder: withMetadata(async function getOrder(input: akash_market_v1beta5_query_pb.QueryOrderRequestJson, options?: CallOptions) {
+          getOrder: withMetadata(async function getOrder(input: akash_market_v1beta5_query.QueryOrderRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getClient(service).order(input, options);
           }, { path: [7, 1] }),
           /**
            * getBids queries bids with filters.
            */
-          getBids: withMetadata(async function getBids(input: akash_market_v1beta5_query_pb.QueryBidsRequestJson, options?: CallOptions) {
+          getBids: withMetadata(async function getBids(input: akash_market_v1beta5_query.QueryBidsRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getClient(service).bids(input, options);
           }, { path: [7, 2] }),
           /**
            * getBid queries bid details.
            */
-          getBid: withMetadata(async function getBid(input: akash_market_v1beta5_query_pb.QueryBidRequestJson, options?: CallOptions) {
+          getBid: withMetadata(async function getBid(input: akash_market_v1beta5_query.QueryBidRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getClient(service).bid(input, options);
           }, { path: [7, 3] }),
           /**
            * getLeases queries leases with filters.
            */
-          getLeases: withMetadata(async function getLeases(input: akash_market_v1beta5_query_pb.QueryLeasesRequestJson, options?: CallOptions) {
+          getLeases: withMetadata(async function getLeases(input: akash_market_v1beta5_query.QueryLeasesRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getClient(service).leases(input, options);
           }, { path: [7, 4] }),
           /**
            * getLease queries lease details.
            */
-          getLease: withMetadata(async function getLease(input: akash_market_v1beta5_query_pb.QueryLeaseRequestJson, options?: CallOptions) {
+          getLease: withMetadata(async function getLease(input: akash_market_v1beta5_query.QueryLeaseRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getClient(service).lease(input, options);
           }, { path: [7, 5] }),
           /**
            * getParams returns the total set of minting parameters.
            */
-          getParams: withMetadata(async function getParams(input: akash_market_v1beta5_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: akash_market_v1beta5_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(7);
             return getClient(service).params(input, options);
           }, { path: [7, 6] }),
           /**
            * createBid defines a method to create a bid given proper inputs.
            */
-          createBid: withMetadata(async function createBid(input: akash_market_v1beta5_bidmsg_pb.MsgCreateBidJson, options?: TxCallOptions) {
+          createBid: withMetadata(async function createBid(input: akash_market_v1beta5_bidmsg.MsgCreateBidJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(8);
             return getMsgClient(service).createBid(input, options);
           }, { path: [8, 0] }),
           /**
            * closeBid defines a method to close a bid given proper inputs.
            */
-          closeBid: withMetadata(async function closeBid(input: akash_market_v1beta5_bidmsg_pb.MsgCloseBidJson, options?: TxCallOptions) {
+          closeBid: withMetadata(async function closeBid(input: akash_market_v1beta5_bidmsg.MsgCloseBidJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(8);
             return getMsgClient(service).closeBid(input, options);
           }, { path: [8, 1] }),
           /**
            * withdrawLease withdraws accrued funds from the lease payment
            */
-          withdrawLease: withMetadata(async function withdrawLease(input: akash_market_v1beta5_leasemsg_pb.MsgWithdrawLeaseJson, options?: TxCallOptions) {
+          withdrawLease: withMetadata(async function withdrawLease(input: akash_market_v1beta5_leasemsg.MsgWithdrawLeaseJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(8);
             return getMsgClient(service).withdrawLease(input, options);
           }, { path: [8, 2] }),
           /**
            * createLease creates a new lease
            */
-          createLease: withMetadata(async function createLease(input: akash_market_v1beta5_leasemsg_pb.MsgCreateLeaseJson, options?: TxCallOptions) {
+          createLease: withMetadata(async function createLease(input: akash_market_v1beta5_leasemsg.MsgCreateLeaseJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(8);
             return getMsgClient(service).createLease(input, options);
           }, { path: [8, 3] }),
           /**
            * closeLease defines a method to close an order given proper inputs.
            */
-          closeLease: withMetadata(async function closeLease(input: akash_market_v1beta5_leasemsg_pb.MsgCloseLeaseJson, options?: TxCallOptions) {
+          closeLease: withMetadata(async function closeLease(input: akash_market_v1beta5_leasemsg.MsgCloseLeaseJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(8);
             return getMsgClient(service).closeLease(input, options);
           }, { path: [8, 4] }),
@@ -319,7 +319,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: akash v1.0.0
            */
-          updateParams: withMetadata(async function updateParams(input: akash_market_v1beta5_paramsmsg_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: akash_market_v1beta5_paramsmsg.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(8);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [8, 5] })
@@ -330,35 +330,35 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getProviders queries providers
            */
-          getProviders: withMetadata(async function getProviders(input: akash_provider_v1beta4_query_pb.QueryProvidersRequestJson, options?: CallOptions) {
+          getProviders: withMetadata(async function getProviders(input: akash_provider_v1beta4_query.QueryProvidersRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(9);
             return getClient(service).providers(input, options);
           }, { path: [9, 0] }),
           /**
            * getProvider queries provider details
            */
-          getProvider: withMetadata(async function getProvider(input: akash_provider_v1beta4_query_pb.QueryProviderRequestJson, options?: CallOptions) {
+          getProvider: withMetadata(async function getProvider(input: akash_provider_v1beta4_query.QueryProviderRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(9);
             return getClient(service).provider(input, options);
           }, { path: [9, 1] }),
           /**
            * createProvider defines a method that creates a provider given the proper inputs.
            */
-          createProvider: withMetadata(async function createProvider(input: akash_provider_v1beta4_msg_pb.MsgCreateProviderJson, options?: TxCallOptions) {
+          createProvider: withMetadata(async function createProvider(input: akash_provider_v1beta4_msg.MsgCreateProviderJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(10);
             return getMsgClient(service).createProvider(input, options);
           }, { path: [10, 0] }),
           /**
            * updateProvider defines a method that updates a provider given the proper inputs.
            */
-          updateProvider: withMetadata(async function updateProvider(input: akash_provider_v1beta4_msg_pb.MsgUpdateProviderJson, options?: TxCallOptions) {
+          updateProvider: withMetadata(async function updateProvider(input: akash_provider_v1beta4_msg.MsgUpdateProviderJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(10);
             return getMsgClient(service).updateProvider(input, options);
           }, { path: [10, 1] }),
           /**
            * deleteProvider defines a method that deletes a provider given the proper inputs.
            */
-          deleteProvider: withMetadata(async function deleteProvider(input: akash_provider_v1beta4_msg_pb.MsgDeleteProviderJson, options?: TxCallOptions) {
+          deleteProvider: withMetadata(async function deleteProvider(input: akash_provider_v1beta4_msg.MsgDeleteProviderJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(10);
             return getMsgClient(service).deleteProvider(input, options);
           }, { path: [10, 2] })
@@ -369,7 +369,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getParams returns the total set of minting parameters.
            */
-          getParams: withMetadata(async function getParams(input: akash_staking_v1beta3_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: akash_staking_v1beta3_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(11);
             return getClient(service).params(input, options);
           }, { path: [11, 0] }),
@@ -379,7 +379,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: akash v1.0.0
            */
-          updateParams: withMetadata(async function updateParams(input: akash_staking_v1beta3_paramsmsg_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: akash_staking_v1beta3_paramsmsg.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(12);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [12, 0] })
@@ -390,7 +390,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
           /**
            * getParams returns the total set of minting parameters.
            */
-          getParams: withMetadata(async function getParams(input: akash_take_v1_query_pb.QueryParamsRequestJson = {}, options?: CallOptions) {
+          getParams: withMetadata(async function getParams(input: akash_take_v1_query.QueryParamsRequestJson = {}, options?: CallOptions) {
             const service = await serviceLoader.loadAt(13);
             return getClient(service).params(input, options);
           }, { path: [13, 0] }),
@@ -400,7 +400,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            *
            * Since: akash v1.0.0
            */
-          updateParams: withMetadata(async function updateParams(input: akash_take_v1_paramsmsg_pb.MsgUpdateParamsJson, options?: TxCallOptions) {
+          updateParams: withMetadata(async function updateParams(input: akash_take_v1_paramsmsg.MsgUpdateParamsJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(14);
             return getMsgClient(service).updateParams(input, options);
           }, { path: [14, 0] })

--- a/ts/src/generated/createProviderSDK.ts
+++ b/ts/src/generated/createProviderSDK.ts
@@ -1,5 +1,5 @@
 import type * as bufbuild_protobuf_wkt from "@bufbuild/protobuf/wkt";
-import type * as akash_provider_lease_v1_service_pb from "./protos/akash/provider/lease/v1/service_pb.ts";
+import type * as akash_provider_lease_v1_service from "./protos/akash/provider/lease/v1/service_pb.ts";
 import { createClientFactory } from "../client/createClientFactory.ts";
 import type { Transport, CallOptions } from "../transport/types.ts";
 import type { SDKOptions } from "../sdk/types.ts";
@@ -55,35 +55,35 @@ export function createSDK(transport: Transport, options?: SDKOptions) {
             /**
              * sendManifest sends manifest to the provider
              */
-            sendManifest: withMetadata(async function sendManifest(input: akash_provider_lease_v1_service_pb.SendManifestRequestJson, options?: CallOptions) {
+            sendManifest: withMetadata(async function sendManifest(input: akash_provider_lease_v1_service.SendManifestRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(2);
               return getClient(service).sendManifest(input, options);
             }, { path: [2, 0] }),
             /**
              * serviceStatus
              */
-            serviceStatus: withMetadata(async function serviceStatus(input: akash_provider_lease_v1_service_pb.ServiceStatusRequestJson, options?: CallOptions) {
+            serviceStatus: withMetadata(async function serviceStatus(input: akash_provider_lease_v1_service.ServiceStatusRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(2);
               return getClient(service).serviceStatus(input, options);
             }, { path: [2, 1] }),
             /**
              * streamServiceStatus
              */
-            streamServiceStatus: withMetadata(async function streamServiceStatus(input: akash_provider_lease_v1_service_pb.ServiceStatusRequestJson, options?: CallOptions) {
+            streamServiceStatus: withMetadata(async function streamServiceStatus(input: akash_provider_lease_v1_service.ServiceStatusRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(2);
               return getClient(service).streamServiceStatus(input, options);
             }, { path: [2, 2] }),
             /**
              * serviceLogs
              */
-            serviceLogs: withMetadata(async function serviceLogs(input: akash_provider_lease_v1_service_pb.ServiceLogsRequestJson, options?: CallOptions) {
+            serviceLogs: withMetadata(async function serviceLogs(input: akash_provider_lease_v1_service.ServiceLogsRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(2);
               return getClient(service).serviceLogs(input, options);
             }, { path: [2, 3] }),
             /**
              * streamServiceLogs
              */
-            streamServiceLogs: withMetadata(async function streamServiceLogs(input: akash_provider_lease_v1_service_pb.ServiceLogsRequestJson, options?: CallOptions) {
+            streamServiceLogs: withMetadata(async function streamServiceLogs(input: akash_provider_lease_v1_service.ServiceLogsRequestJson, options?: CallOptions) {
               const service = await serviceLoader.loadAt(2);
               return getClient(service).streamServiceLogs(input, options);
             }, { path: [2, 4] })

--- a/ts/src/sdk/nodejs/createProviderSDK.ts
+++ b/ts/src/sdk/nodejs/createProviderSDK.ts
@@ -1,0 +1,33 @@
+import { createSDK } from "../../generated/createProviderSDK.ts";
+import { createGrpcTransport } from "../../transport/grpc/createGrpcTransport.ts";
+import type { PickByPath } from "../../utils/types.ts";
+
+type ProviderSDK = PickByPath<ReturnType<typeof createSDK>, "akash.provider.v1">;
+
+export function createProviderSDK(options: ProviderSDKOptions): ProviderSDK {
+  const certificateOptions = options.authentication?.type === "certificate"
+    ? {
+        cert: options.authentication?.cert,
+        key: options.authentication?.key,
+      }
+    : null;
+
+  return createSDK(
+    createGrpcTransport({
+      baseUrl: options.baseUrl,
+      nodeOptions: {
+        ...certificateOptions,
+        rejectUnauthorized: false,
+      },
+    }),
+  );
+}
+
+export interface ProviderSDKOptions {
+  baseUrl: string;
+  authentication?: {
+    type: "certificate";
+    cert: string;
+    key: string;
+  };
+}

--- a/ts/src/sdk/types.ts
+++ b/ts/src/sdk/types.ts
@@ -1,4 +1,4 @@
-import type { ServiceClientOptions } from "src/client/createServiceClient";
+import type { ServiceClientOptions } from "../client/createServiceClient.ts";
 export interface SDKOptions {
   clientOptions?: ServiceClientOptions;
 }

--- a/ts/src/transport/grpc/createGrpcTransport.ts
+++ b/ts/src/transport/grpc/createGrpcTransport.ts
@@ -1,0 +1,10 @@
+import { createGrpcTransport as makeGrpcTransport, type GrpcTransportOptions } from "@connectrpc/connect-node";
+
+import type { Transport } from "../types.ts";
+
+export function createGrpcTransport(options: Omit<GrpcTransportOptions, "useBinaryFormat">): Transport {
+  return makeGrpcTransport({
+    ...options,
+    useBinaryFormat: true,
+  });
+}

--- a/ts/src/utils/types.ts
+++ b/ts/src/utils/types.ts
@@ -1,0 +1,11 @@
+export type DeepReadonly<T> = {
+  readonly [P in keyof T]: T[P] extends object ? DeepReadonly<T[P]> : T[P];
+};
+
+export type PickByPath<T, Path extends string> = Path extends `${infer First}.${infer Rest}`
+  ? First extends keyof T
+    ? { [K in First]: PickByPath<T[First], Rest> }
+    : never
+  : Path extends keyof T
+    ? { [K in Path]: T[Path] }
+    : never;

--- a/ts/test/functional/__snapshots__/protoc-gen-sdk-object.spec.ts.snap
+++ b/ts/test/functional/__snapshots__/protoc-gen-sdk-object.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`protoc-sdk-objec plugin generates SDK object from proto files 1`] = `
-"import type * as msg_pb from "./protos/msg_pb.none";
-import type * as query_pb from "./protos/query_pb.none";
+"import type * as msg from "./protos/msg_pb.none";
+import type * as query from "./protos/query_pb.none";
 import { createClientFactory } from "../client/createClientFactory.none";
 import type { Transport, CallOptions, TxCallOptions } from "../transport/types.none";
 import type { SDKOptions } from "../sdk/types.none";
@@ -21,11 +21,11 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
     akash: {
       test: {
         functional: {
-          send: withMetadata(async function send(input: msg_pb.SendRequestJson, options?: TxCallOptions) {
+          send: withMetadata(async function send(input: msg.SendRequestJson, options?: TxCallOptions) {
             const service = await serviceLoader.loadAt(0);
             return getMsgClient(service).send(input, options);
           }, { path: [0, 0] }),
-          getBlock: withMetadata(async function getBlock(input: query_pb.GetBlockRequestJson, options?: CallOptions) {
+          getBlock: withMetadata(async function getBlock(input: query.GetBlockRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).getBlock(input, options);
           }, { path: [1, 0] }),
@@ -33,7 +33,7 @@ export function createSDK(queryTransport: Transport, txTransport: Transport, opt
            * getBlockByHeight is deprecated. Use GetBlock instead.
            * @deprecated
            */
-          getBlockByHeight: withMetadata(async function getBlockByHeight(input: query_pb.GetBlockByHeightRequestJson, options?: CallOptions) {
+          getBlockByHeight: withMetadata(async function getBlockByHeight(input: query.GetBlockByHeightRequestJson, options?: CallOptions) {
             const service = await serviceLoader.loadAt(1);
             return getClient(service).getBlockByHeight(input, options);
           }, { path: [1, 1] })

--- a/ts/tsconfig.build.json
+++ b/ts/tsconfig.build.json
@@ -1,5 +1,14 @@
 {
+  "compilerOptions": {
+    "outDir": "dist/types"
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "test/**/*",
+    "script/**/*"
+  ],
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "src/**/*.spec.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -12,7 +12,8 @@
       "ESNext",
       "DOM"
     ],
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "noImplicitAny": true,
     "outDir": "./dist",
     "paths": {
@@ -26,6 +27,6 @@
     "target": "es2022"
   },
   "include": [
-    "src/**/*.ts"
+    "**/*.ts"
   ]
 }


### PR DESCRIPTION
## Why

to have an easy interface to communicate with provider api over GRPC

## What

adds support for provider sdk. Usage:

```ts
import { createProviderSDK } from '@akashnetwork/akash-api/provider';

const sdk = createProviderSDK({
  baseUrl: "https://provider.hurricane.akash.pub:8444",
});

const statusStream = await sdk.akash.provider.v1.streamStatus();
for await (const status of statusStream) {
  console.dir(status, { depth: null });
}
```

also added esbuild setup to build this into js code
