### PR TITLE
feat: adds tx transport and chain sdk for nodejs env

### DIFF
--- a/ts/src/sdk/nodejs/createChainNodeSDK.ts
+++ b/ts/src/sdk/nodejs/createChainNodeSDK.ts
@@ -1,0 +1,35 @@
+import { createSDK as createCosmosSDK, serviceLoader as cosmosServiceLoader } from "../../generated/createCosmosSDK.ts";
+import { createSDK as createNodeSDK, serviceLoader as nodeServiceLoader } from "../../generated/createNodeSDK.ts";
+import { TxRawSchema } from "../../generated/protos/cosmos/tx/v1beta1/tx_pb.ts";
+import { createGrpcTransport } from "../../transport/grpc/createGrpcTransport.ts";
+import { createTxTransport } from "../../transport/tx/createTxTransport.ts";
+import type { StargateClientOptions } from "../../transport/tx/txClient/createStargateClient.ts";
+import { createStargateClient } from "../../transport/tx/txClient/createStargateClient.ts";
+import { createMessageType } from "../../utils/createServiceLoader.ts";
+
+export function createChainNodeSDK(options: ChainNodeSDKOptions) {
+  const queryTransport = createGrpcTransport({
+    baseUrl: options.query.baseUrl,
+  });
+  const getMessageType: StargateClientOptions["getMessageType"] = (typeUrl) => nodeServiceLoader.getLoadedType(typeUrl) || cosmosServiceLoader.getLoadedType(typeUrl);
+  const txTransport = createTxTransport({
+    getMessageType,
+    client: createStargateClient({
+      ...options.tx,
+      getMessageType,
+      builtInTypes: [
+        createMessageType(TxRawSchema),
+      ],
+    }),
+  });
+  const nodeSDK = createNodeSDK(queryTransport, txTransport);
+  const cosmosSDK = createCosmosSDK(queryTransport, txTransport);
+  return { ...nodeSDK, ...cosmosSDK };
+}
+
+export interface ChainNodeSDKOptions {
+  query: {
+    baseUrl: string;
+  };
+  tx: Omit<StargateClientOptions, "getMessageType" | "builtInTypes">;
+}

--- a/ts/src/transport/tx/TxClient.ts
+++ b/ts/src/transport/tx/TxClient.ts
@@ -1,0 +1,13 @@
+import type { EncodeObject, GeneratedType } from "@cosmjs/proto-signing";
+import type { DeliverTxResponse, StdFee } from "@cosmjs/stargate";
+
+import type { TxRaw as GenTxRaw } from "../../generated/protos/cosmos/tx/v1beta1/tx_pb.ts";
+
+export type TxRaw = Omit<GenTxRaw, "$typeName" | "$unknown">;
+export { DeliverTxResponse, StdFee, EncodeObject, GeneratedType };
+
+export interface TxClient {
+  estimateFee(messages: EncodeObject[], memo?: string): Promise<StdFee>;
+  sign(messages: EncodeObject[], fee: StdFee, memo: string): Promise<TxRaw>;
+  broadcast(signedMessages: TxRaw): Promise<DeliverTxResponse>;
+}

--- a/ts/src/transport/tx/TxError.ts
+++ b/ts/src/transport/tx/TxError.ts
@@ -1,0 +1,11 @@
+import type { DeliverTxResponse } from "@cosmjs/stargate";
+
+export class TxError extends Error {
+  readonly txResponse: DeliverTxResponse;
+
+  constructor(message: string, txResponse: DeliverTxResponse) {
+    super(message);
+    this.name = this.constructor.name;
+    this.txResponse = txResponse;
+  }
+}

--- a/ts/src/transport/tx/createTxTransport.spec.ts
+++ b/ts/src/transport/tx/createTxTransport.spec.ts
@@ -1,0 +1,221 @@
+import type { DescMessage, DescMethodBiDiStreaming, DescMethodUnary } from "@bufbuild/protobuf";
+import type { DeliverTxResponse, StdFee } from "@cosmjs/stargate";
+import { describe, expect, it, jest } from "@jest/globals";
+import { proto } from "@test/helpers/proto";
+
+import { createAsyncIterable } from "../../utils/stream.ts";
+import { createTxTransport } from "./createTxTransport.ts";
+import type { TxClient, TxRaw } from "./TxClient.ts";
+import { TxError } from "./TxError.ts";
+
+describe(createTxTransport.name, () => {
+  describe("stream", () => {
+    it("throws when `stream` method is called", async () => {
+      const { TestServiceSchema } = await setup();
+      const transport = createTxTransport({
+        client: createMockTxClient(),
+        getMessageType,
+      });
+
+      await expect(transport.stream(TestServiceSchema.method.streamMethod, createAsyncIterable([{ test: "input" }]))).rejects.toThrow(/not supported/i);
+    });
+  });
+
+  describe("unary", () => {
+    it("calls `estimateFee` if no fee is provided", async () => {
+      const { TestServiceSchema } = await setup();
+      const fee: StdFee = {
+        amount: [{ denom: "uakt", amount: "100000" }],
+        gas: "100000",
+      };
+      const client = createMockTxClient({ estimateFee: jest.fn(() => Promise.resolve(fee)) });
+      const transport = createTxTransport({
+        client,
+        getMessageType,
+      });
+
+      await transport.unary(TestServiceSchema.method.testMethod, { test: "input" });
+
+      expect(client.estimateFee).toHaveBeenCalled();
+      expect(client.sign).toHaveBeenCalledWith(expect.anything(), fee, expect.anything());
+    });
+
+    it("does not `estimateFee` if a fee is provided", async () => {
+      const { TestServiceSchema } = await setup();
+      const client = createMockTxClient();
+      const transport = createTxTransport({
+        client,
+        getMessageType,
+      });
+      const fee: StdFee = {
+        amount: [{ denom: "uakt", amount: "100000" }],
+        gas: "100000",
+      };
+
+      await transport.unary(TestServiceSchema.method.testMethod, { test: "input" }, {
+        fee,
+      });
+
+      expect(client.estimateFee).not.toHaveBeenCalled();
+      expect(client.sign).toHaveBeenCalledWith(expect.anything(), fee, expect.anything());
+    });
+
+    it("signs and broadcasts a transaction with single message", async () => {
+      const { TestServiceSchema } = await setup();
+      const fee: StdFee = {
+        amount: [{ denom: "uakt", amount: "100000" }],
+        gas: "100000",
+      };
+      const txRaw: TxRaw = {
+        bodyBytes: new Uint8Array(0),
+        authInfoBytes: new Uint8Array(0),
+        signatures: [],
+      };
+      const txResponse: DeliverTxResponse = {
+        height: 1,
+        txIndex: 0,
+        code: 0,
+        transactionHash: "123",
+        events: [],
+        msgResponses: [],
+        gasUsed: 1n,
+        gasWanted: 1n,
+      };
+      const client = createMockTxClient({
+        estimateFee: jest.fn(() => Promise.resolve(fee)),
+        sign: jest.fn(() => Promise.resolve(txRaw)),
+        broadcast: jest.fn(() => Promise.resolve(txResponse)),
+      });
+      const transport = createTxTransport({
+        client,
+        getMessageType,
+      });
+
+      const afterSign = jest.fn();
+      const afterBroadcast = jest.fn();
+      const result = await transport.unary(TestServiceSchema.method.testMethod, { test: "input" }, {
+        memo: "test",
+        afterSign,
+        afterBroadcast,
+      });
+      const messages = [{
+        typeUrl: `/${TestServiceSchema.method.testMethod.input.typeName}`,
+        value: { test: "input" },
+      }];
+
+      expect(client.estimateFee).toHaveBeenCalledWith(messages, "test");
+      expect(client.sign).toHaveBeenCalledWith(messages, fee, "test");
+      expect(afterSign).toHaveBeenCalledWith(txRaw);
+      expect(client.broadcast).toHaveBeenCalledWith(txRaw);
+      expect(afterBroadcast).toHaveBeenCalledWith(txResponse);
+      expect(result.message).toEqual({});
+    });
+
+    it("decodes response if `msgResponses` has a response", async () => {
+      const { TestServiceSchema } = await setup();
+      const client = createMockTxClient({
+        broadcast: jest.fn(() => Promise.resolve({
+          height: 1,
+          txIndex: 0,
+          code: 0,
+          transactionHash: "123",
+          events: [],
+          msgResponses: [{
+            typeUrl: `/${TestServiceSchema.method.testMethod.output.typeName}`,
+            value: new Uint8Array(0),
+          }],
+          gasUsed: 1n,
+          gasWanted: 1n,
+        })),
+      });
+      const transport = createTxTransport({
+        client,
+        getMessageType: (typeUrl) => ({
+          ...getMessageType(),
+          decode: jest.fn(() => (typeUrl === `/${TestServiceSchema.method.testMethod.output.typeName}` ? { test: "output", ok: true } : null)),
+        }),
+      });
+
+      const result = await transport.unary(TestServiceSchema.method.testMethod, { test: "input" });
+      expect(result.message).toEqual({ test: "output", ok: true });
+    });
+
+    it("throws if tx response has a non-zero code", async () => {
+      const { TestServiceSchema } = await setup();
+      const client = createMockTxClient({
+        broadcast: jest.fn(() => Promise.resolve({
+          height: 1,
+          txIndex: 0,
+          code: 1,
+          transactionHash: "123",
+          events: [],
+          msgResponses: [],
+          gasUsed: 1n,
+          gasWanted: 1n,
+        })),
+      });
+      const transport = createTxTransport({
+        client,
+        getMessageType,
+      });
+
+      await expect(transport.unary(TestServiceSchema.method.testMethod, { test: "input" })).rejects.toThrow(TxError);
+    });
+  });
+
+  async function setup() {
+    const def = await proto`
+      service TestService {
+        rpc TestMethod(TestInput) returns (TestOutput);
+        rpc StreamMethod(stream TestInput) returns (stream TestOutput);
+      }
+
+      message TestInput {
+        string test = 1;
+      }
+
+      message TestOutput {
+        string result = 1;
+      }
+    `;
+    const TestServiceSchema = def.getService<{
+      testMethod: DescMethodUnary<DescMessage, DescMessage>;
+      streamMethod: DescMethodBiDiStreaming<DescMessage, DescMessage>;
+    }>("TestService");
+
+    return { TestServiceSchema };
+  }
+
+  function createMockTxClient(overrides?: Partial<TxClient>): TxClient {
+    return {
+      broadcast: jest.fn(() => Promise.resolve({
+        height: 1,
+        txIndex: 0,
+        code: 0,
+        transactionHash: "123",
+        events: [],
+        msgResponses: [],
+        gasUsed: 1n,
+        gasWanted: 1n,
+      })),
+      estimateFee: jest.fn(() => Promise.resolve({
+        amount: [],
+        gas: "100000",
+      })),
+      sign: jest.fn(() => Promise.resolve({
+        bodyBytes: new Uint8Array(0),
+        authInfoBytes: new Uint8Array(0),
+        signatures: [],
+      })),
+      ...overrides,
+    };
+  }
+
+  function getMessageType() {
+    return {
+      decode: jest.fn(),
+      encode: jest.fn(),
+      fromPartial: jest.fn(),
+    };
+  }
+});

--- a/ts/src/transport/tx/createTxTransport.ts
+++ b/ts/src/transport/tx/createTxTransport.ts
@@ -1,0 +1,52 @@
+import type { DescMessage, DescMethodUnary, MessageShape } from "@bufbuild/protobuf";
+import type { UnaryResponse } from "@connectrpc/connect";
+import type { GeneratedType } from "@cosmjs/proto-signing";
+
+import type { Transport, TxCallOptions } from "../types.ts";
+import type { TxClient } from "./TxClient.ts";
+import { TxError } from "./TxError.ts";
+
+export function createTxTransport(transportOptions: TransactionTransportOptions): Transport<TxCallOptions> {
+  return {
+    async unary<I extends DescMessage, O extends DescMessage>(
+      method: DescMethodUnary<I, O>,
+      input: MessageShape<I>,
+      options?: TxCallOptions,
+    ): Promise<UnaryResponse<I, O>> {
+      const messages = [{
+        typeUrl: `/${method.input.typeName}`,
+        value: input,
+      }];
+      const memo = options?.memo ?? `akash: ${method.name}`;
+      const fee = options?.fee ?? await transportOptions.client.estimateFee(messages, memo);
+
+      const txRaw = await transportOptions.client.sign(messages, fee, memo);
+      options?.afterSign?.(txRaw);
+      const txResponse = await transportOptions.client.broadcast(txRaw);
+      options?.afterBroadcast?.(txResponse);
+
+      if (txResponse.code !== 0) {
+        throw new TxError(`Transaction failed with code ${txResponse.code}`, txResponse);
+      }
+
+      const response = txResponse.msgResponses[0];
+
+      return {
+        stream: false,
+        header: new Headers(),
+        trailer: new Headers(),
+        message: (response ? transportOptions.getMessageType(response.typeUrl).decode(response.value) : {}) as MessageShape<O>,
+        service: method.parent,
+        method,
+      };
+    },
+    async stream() {
+      throw new Error("Not supported");
+    },
+  };
+}
+
+export interface TransactionTransportOptions {
+  client: TxClient;
+  getMessageType: (typeUrl: string) => GeneratedType;
+}

--- a/ts/src/transport/tx/txClient/createStargateClient.spec.ts
+++ b/ts/src/transport/tx/txClient/createStargateClient.spec.ts
@@ -1,0 +1,99 @@
+import type {
+  EncodeObject,
+  OfflineSigner,
+} from "@cosmjs/proto-signing";
+import type { SigningStargateClient, StdFee } from "@cosmjs/stargate";
+import { describe, expect, it, jest } from "@jest/globals";
+
+import type { TxClient } from "../TxClient.ts";
+import { createStargateClient } from "./createStargateClient.ts";
+
+describe(createStargateClient.name, () => {
+  const MESSAGE_TYPE = "/test.type";
+
+  describe("sign", () => {
+    includeSigningTests(async (client) => {
+      const messages: EncodeObject[] = [{ typeUrl: MESSAGE_TYPE, value: {} }];
+      const fee: StdFee = { amount: [], gas: "1000" };
+      await client.sign(messages, fee, "test memo");
+    });
+  });
+
+  describe("estimateFee", () => {
+    includeSigningTests(async (client) => {
+      const messages: EncodeObject[] = [{ typeUrl: MESSAGE_TYPE, value: {} }];
+      await client.estimateFee(messages, "test memo");
+    });
+  });
+
+  function includeSigningTests(sign: (client: TxClient) => Promise<unknown>) {
+    it("does not calls `getMessageType` when signing message with types that are already registered", async () => {
+      const getMessageType = jest.fn(() => {
+        throw new Error("no types");
+      });
+      const client = createStargateClient({
+        baseUrl: "https://rpc.akash.network",
+        signer: createOfflineSigner(),
+        builtInTypes: [{
+          typeUrl: MESSAGE_TYPE,
+          encode: () => new Uint8Array(0),
+          decode: () => ({}),
+          fromPartial: () => ({}),
+        }],
+        getMessageType,
+        createClient: async () => ({
+          sign: jest.fn(),
+          simulate: jest.fn(),
+          broadcastTx: jest.fn(),
+        } as unknown as SigningStargateClient),
+      });
+
+      await sign(client);
+
+      expect(getMessageType).not.toHaveBeenCalled();
+    });
+
+    it("calls `getMessageType` when signing message with types that are not registered", async () => {
+      const getMessageType = jest.fn(() => ({
+        typeUrl: MESSAGE_TYPE,
+        encode: () => new Uint8Array(0),
+        decode: () => ({}),
+        fromPartial: () => ({}),
+      }));
+      const client = createStargateClient({
+        baseUrl: "https://rpc.akash.network",
+        signer: createOfflineSigner(),
+        getMessageType,
+        createClient: async () => ({
+          sign: jest.fn(),
+          simulate: jest.fn(),
+          broadcastTx: jest.fn(),
+        } as unknown as SigningStargateClient),
+      });
+
+      await sign(client);
+
+      expect(getMessageType).toHaveBeenCalledWith(MESSAGE_TYPE);
+    });
+  }
+
+  function createOfflineSigner(): OfflineSigner {
+    return {
+      getAccounts: async () => [{
+        address: "test-address",
+        algo: "secp256k1",
+        pubkey: new Uint8Array(),
+      }],
+      signDirect: async (_, signDoc) => ({
+        signed: signDoc,
+        signature: {
+          pub_key: {
+            type: "tendermint/PubKeySecp256k1",
+            value: new Uint8Array(0),
+          },
+          signature: "test-signature",
+        },
+      }),
+    };
+  }
+});

--- a/ts/src/transport/tx/txClient/createStargateClient.ts
+++ b/ts/src/transport/tx/txClient/createStargateClient.ts
@@ -1,0 +1,107 @@
+import type {
+  EncodeObject,
+  GeneratedType,
+  OfflineSigner,
+} from "@cosmjs/proto-signing";
+import {
+  Registry,
+} from "@cosmjs/proto-signing";
+import type {
+  HttpEndpoint,
+  SigningStargateClientOptions,
+} from "@cosmjs/stargate";
+import {
+  defaultRegistryTypes,
+  SigningStargateClient,
+} from "@cosmjs/stargate";
+
+import type { TxClient } from "../TxClient.ts";
+
+const DEFAULT_FEE_AMOUNT = "2500";
+const GAS_MULTIPLIER = 1.2;
+
+export function createStargateClient(options: StargateClientOptions): TxClient {
+  const builtInTypes = options.builtInTypes?.map((type) => [type.typeUrl, type] as [string, GeneratedType]) || [];
+  const registry = new Registry([...defaultRegistryTypes, ...builtInTypes]);
+  const createStargateClient = options.createClient ?? SigningStargateClient.connectWithSigner;
+
+  let stargateClient: SigningStargateClient | undefined;
+  const getStargateClient = async () => stargateClient ??= await createStargateClient(
+    options.baseUrl,
+    options.signer,
+    {
+      ...options.stargateOptions,
+      registry,
+    },
+  );
+
+  const getAccount = options.getAccount ?? (() => getDefaultAccount(options.signer));
+  const preloadMessageTypes = (messages: EncodeObject[]) => {
+    for (const message of messages) {
+      if (registry.lookupType(message.typeUrl)) continue;
+      const type = options.getMessageType(message.typeUrl);
+      registry.register(message.typeUrl, type);
+    }
+    return messages;
+  };
+
+  return {
+    async estimateFee(messages, memo) {
+      const account = await getAccount(preloadMessageTypes(messages));
+      const client = await getStargateClient();
+      const gas = await client.simulate(account, messages, memo);
+      return {
+        amount: [
+          {
+            denom: "uakt",
+            amount: options.defaultFeeAmount ?? DEFAULT_FEE_AMOUNT,
+          },
+        ],
+        gas: Math.floor(GAS_MULTIPLIER * gas).toString(),
+        granter: account,
+      };
+    },
+    async sign(messages, fee, memo) {
+      const account = await getAccount(preloadMessageTypes(messages));
+      const client = await getStargateClient();
+      return client.sign(account, messages, fee, memo);
+    },
+    async broadcast(txRaw) {
+      const TxRawType = registry.lookupType("/cosmos.tx.v1beta1.TxRaw");
+      if (!TxRawType) {
+        throw new Error("Cannot broadcast transaction: TxRaw type is not registered");
+      }
+      const client = await getStargateClient();
+      return client.broadcastTx(
+        TxRawType.encode(txRaw).finish(),
+        options.stargateOptions?.broadcastTimeoutMs,
+        options.stargateOptions?.broadcastPollIntervalMs,
+      );
+    },
+  };
+}
+
+export interface StargateClientOptions {
+  baseUrl: string;
+  signer: OfflineSigner;
+  /**
+   * @default "2500" uakt
+   */
+  defaultFeeAmount?: string;
+  /**
+   * @default returns the first account from the signer
+   */
+  getAccount?(messages: EncodeObject[]): Promise<string>;
+  stargateOptions?: SigningStargateClientOptions;
+  builtInTypes?: Array<GeneratedType & { typeUrl: string }>;
+  getMessageType: (typeUrl: string) => GeneratedType;
+  /**
+   * @default `SigningStargateClient.connectWithSigner`
+   */
+  createClient?: (endpoint: string | HttpEndpoint, signer: OfflineSigner, options?: SigningStargateClientOptions) => Promise<SigningStargateClient>;
+}
+
+async function getDefaultAccount(signer: OfflineSigner) {
+  const account = await signer.getAccounts();
+  return account[0].address;
+}

--- a/ts/src/utils/createServiceLoader.ts
+++ b/ts/src/utils/createServiceLoader.ts
@@ -1,5 +1,5 @@
-import type { DescMessage, DescService, JsonValue, MessageJsonType } from "@bufbuild/protobuf";
-import { fromBinary, fromJson, toBinary, toJson } from "@bufbuild/protobuf";
+import type { DescMessage, DescService, MessageInitShape, MessageShape } from "@bufbuild/protobuf";
+import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import type { BinaryReader } from "@bufbuild/protobuf/wire";
 import { BinaryWriter } from "@bufbuild/protobuf/wire";
 
@@ -12,7 +12,11 @@ export function createServiceLoader<T extends ReadonlyArray<LoadGrpcService>>(fn
   const loadedTypes: Record<string, GRPCMessageType> = {};
   return {
     getLoadedType(typeUrl) {
-      return loadedTypes[typeUrl];
+      const type = loadedTypes[typeUrl];
+      if (!type) {
+        throw new Error(`Cannot find message type ${typeUrl} in service loader. Probably it's not loaded yet.`);
+      }
+      return type;
     },
     async loadAt(index) {
       const service = await fns[index]() as DescService;
@@ -35,27 +39,28 @@ export function createMessageType<T extends DescMessage>(schema: T): GRPCMessage
   return {
     typeUrl: `/${schema.typeName}`,
     encode(message, writer = new BinaryWriter()) {
-      const bytes = toBinary(schema, fromJson(schema, message as JsonValue));
+      const object = message.$typeName ? message as MessageShape<T> : create(schema, message as MessageInitShape<T>);
+      const bytes = toBinary(schema, object);
       writer.raw(bytes);
       return writer;
     },
     decode(input) {
       const bytes = input instanceof Uint8Array ? input : (input as unknown as { buf: Uint8Array }).buf;
-      return toJson(schema, fromBinary(schema, bytes)) as MessageJsonType<T>;
+      return fromBinary(schema, bytes);
     },
     fromPartial(message) {
-      return toJson(schema, fromJson(schema, message as JsonValue)) as T;
+      return create(schema, message);
     },
   };
 }
 export interface GRPCMessageType<T extends DescMessage = DescMessage> {
   typeUrl: string;
-  encode(message: MessageJsonType<T>, writer?: BinaryWriter): BinaryWriter;
-  decode(input: Uint8Array | BinaryReader, length?: number): MessageJsonType<T>;
-  fromPartial(message: unknown): T;
+  encode(message: MessageShape<T> | MessageInitShape<T>, writer?: BinaryWriter): BinaryWriter;
+  decode(input: Uint8Array | BinaryReader, length?: number): MessageShape<T>;
+  fromPartial(message: MessageInitShape<T>): MessageShape<T>;
 }
 
 export interface ServiceLoader<T extends ReadonlyArray<LoadGrpcService>> {
   loadAt<TIndex extends keyof T & number>(index: TIndex): ReturnType<T[TIndex]>;
-  getLoadedType(typeUrl: string): GRPCMessageType | undefined;
+  getLoadedType(typeUrl: string): GRPCMessageType;
 }


### PR DESCRIPTION
## Why

https://github.com/akash-network/akashjs/issues/118

## What

adds chain sdk for nodejs env (grpc for queries and cosm/stargate for txs)

### Usage

```ts
import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
import { createChainNodeSDK } from "@akash-network/akash-api/chain-node";

const wallet = await DirectSecp256k1HdWallet.fromMnemonic(process.env.MNEMONIC, { prefix: "akash" });
const sdk = createChainNodeSDK({
  query: {
    // baseUrl: "https://grpc17.akashnet.net:10023",
    baseUrl: "https://public-proxy.akt.dev:9090",
  },
  tx: {
    baseUrl: "https://rpc.sandbox-01.aksh.pw:443",
    signer: wallet,
  },
});

const latestBlock = await sdk.cosmos.base.tendermint.v1beta1.getLatestBlock();
console.log(latestBlock);

const certificates = await sdk.akash.cert.v1beta3.getCertificates({
  pagination: {
    limit: "1",
  },
});
console.log(certificates);

// creates transaction here
const response = await sdk.akash.cert.v1beta3.createCertificate({
    owner: '...',
    cert: '..',
    pubkey: '...',
  });
console.log(response)
```