### PR TITLE
feat: adds certificate generation to SDK

### DIFF
--- a/ts/esbuild.config.mjs
+++ b/ts/esbuild.config.mjs
@@ -10,6 +10,7 @@ const baseConfig = (config) => ({
   entryPoints: [
     'src/sdk/nodejs/createProviderSDK.ts',
     'src/sdk/nodejs/createChainNodeSDK.ts',
+    'src/auth/certificates/index.ts',
   ],
   bundle: true,
   sourcemap: true,

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -10,7 +10,8 @@
         "@connectrpc/connect-web": "^2.0.1",
         "@cosmjs/math": "^0.33.1",
         "@cosmjs/proto-signing": "^0.33.1",
-        "@cosmjs/stargate": "^0.33.1"
+        "@cosmjs/stargate": "^0.33.1",
+        "jsrsasign": "^11.1.0"
       },
       "devDependencies": {
         "@bufbuild/protoc-gen-es": "^2.2.3",
@@ -19,6 +20,7 @@
         "@faker-js/faker": "^9.7.0",
         "@jest/globals": "^29.7.0",
         "@stylistic/eslint-plugin": "^4.0.1",
+        "@types/jsrsasign": "^10.5.15",
         "esbuild": "^0.25.2",
         "eslint": "^9.24.0",
         "eslint-plugin-import": "^2.31.0",
@@ -2280,6 +2282,13 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "version": "0.0.29"
+    },
+    "node_modules/@types/jsrsasign": {
+      "dev": true,
+      "integrity": "sha512-3stUTaSRtN09PPzVWR6aySD9gNnuymz+WviNHoTb85dKu+BjaV4uBbWWGykBBJkfwPtcNZVfTn2lbX00U+yhpQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.15.tgz",
+      "version": "10.5.15"
     },
     "node_modules/@types/node": {
       "dependencies": {
@@ -6405,6 +6414,15 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "version": "2.2.3"
+    },
+    "node_modules/jsrsasign": {
+      "funding": {
+        "url": "https://github.com/kjur/jsrsasign#donations"
+      },
+      "integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
+      "version": "11.1.0"
     },
     "node_modules/keyv": {
       "dependencies": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -12,13 +12,15 @@
   "author": "Akash Network Team",
   "type": "module",
   "exports": {
+    "./certificate": {
+      "import": "./dist/nodejs/esm/auth/certificates/index.js",
+      "require": "./dist/nodejs/cjs/auth/certificates/index.js",
+      "types": "./dist/types/auth/certificates/index.d.ts"
+    },
     "./chain-node": {
       "import": "./dist/nodejs/esm/createChainNodeSDK.js",
       "require": "./dist/nodejs/cjs/createChainNodeSDK.js",
       "types": "./dist/types/sdk/nodejs/createChainNodeSDK.d.ts"
-    },
-    "./protos/*": {
-      "types": "./dist/types/generated/protos/*"
     },
     "./provider": {
       "import": "./dist/nodejs/esm/createProviderSDK.js",
@@ -57,7 +59,8 @@
     "@connectrpc/connect-web": "^2.0.1",
     "@cosmjs/math": "^0.33.1",
     "@cosmjs/proto-signing": "^0.33.1",
-    "@cosmjs/stargate": "^0.33.1"
+    "@cosmjs/stargate": "^0.33.1",
+    "jsrsasign": "^11.1.0"
   },
   "devDependencies": {
     "@bufbuild/protoc-gen-es": "^2.2.3",
@@ -66,6 +69,7 @@
     "@faker-js/faker": "^9.7.0",
     "@jest/globals": "^29.7.0",
     "@stylistic/eslint-plugin": "^4.0.1",
+    "@types/jsrsasign": "^10.5.15",
     "esbuild": "^0.25.2",
     "eslint": "^9.24.0",
     "eslint-plugin-import": "^2.31.0",

--- a/ts/src/auth/certificates/CertificateManager.spec.ts
+++ b/ts/src/auth/certificates/CertificateManager.spec.ts
@@ -1,0 +1,97 @@
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "@jest/globals";
+
+import { CertificateManager, dateToStr, strToDate } from "./CertificateManager.ts";
+
+describe("CertificateManager", () => {
+  const generateAddress = () => `akash1${faker.string.alpha({ length: 38 })}`;
+  const ONE_DAY = 1000 * 60 * 60 * 24;
+
+  describe("prototype.generateCertificate", () => {
+    it("generates certificate PEMs with the default validity range", async () => {
+      const manager = setup();
+
+      const now = new Date();
+      now.setMilliseconds(0);
+      const inOneYear = getTime1yearFrom(now);
+      const pem = await manager.generatePEM(generateAddress());
+      const meta = await manager.parsePem(pem.cert);
+
+      expect(pem).toMatchObject({
+        cert: expect.stringMatching(/^-----BEGIN CERTIFICATE-----[\s\S]*-----END CERTIFICATE-----\r\n$/),
+        publicKey: expect.stringMatching(/^-----BEGIN EC PUBLIC KEY-----[\s\S]*-----END EC PUBLIC KEY-----\r\n$/),
+        privateKey: expect.stringMatching(/^-----BEGIN PRIVATE KEY-----[\s\S]*-----END PRIVATE KEY-----\r\n$/),
+      });
+      expect(new Date(meta.issuedOn).getTime()).toBeGreaterThanOrEqual(now.getTime());
+      expect(new Date(meta.issuedOn).getTime()).toBeLessThan(new Date().getTime());
+      expect(new Date(meta.expiresOn).getTime()).toBeGreaterThanOrEqual(inOneYear);
+      expect(new Date(meta.issuedOn).getTime()).toBeLessThan(getTime1yearFrom(new Date()));
+    });
+
+    it("generates certificate PEMs with the provided validity range", async () => {
+      const now = new Date();
+      const inOneMonth = new Date(now.getTime() + 30 * ONE_DAY);
+      const inTwoMonths = new Date(now.getTime() + 2 * 30 * ONE_DAY);
+      const manager = setup();
+      const pem = await manager.generatePEM(generateAddress(), {
+        validFrom: inOneMonth,
+        validTo: inTwoMonths,
+      });
+      const meta = await manager.parsePem(pem.cert);
+
+      inOneMonth.setMilliseconds(0);
+      inTwoMonths.setMilliseconds(0);
+
+      expect(new Date(meta.issuedOn).getTime()).toBe(inOneMonth.getTime());
+      expect(new Date(meta.expiresOn).getTime()).toBe(inTwoMonths.getTime());
+    });
+  });
+
+  describe("prototype.parsePem", () => {
+    it("extracts certificate details", async () => {
+      const manager = setup();
+
+      const pem = await manager.generatePEM(generateAddress());
+      const cert = await manager.parsePem(pem.cert);
+
+      expect(cert).toMatchObject({
+        hSerial: expect.any(String),
+        sIssuer: expect.any(String),
+        sSubject: expect.any(String),
+        sNotBefore: expect.any(String),
+        sNotAfter: expect.any(String),
+        issuedOn: expect.any(Date),
+        expiresOn: expect.any(Date),
+      });
+    });
+  });
+
+  describe("prototype.strToDate", () => {
+    it("should convert string to date", () => {
+      const date = strToDate("240507122350Z");
+
+      expect(date).toBeInstanceOf(Date);
+      expect(date.toISOString()).toBe("2024-05-07T12:23:50.000Z");
+    });
+  });
+
+  describe("prototype.dateToStr", () => {
+    it("should convert date to string", () => {
+      const date = new Date("2024-05-07T12:23:50.000Z");
+      const str = dateToStr(date);
+
+      expect(str).toBe("240507122350Z");
+    });
+  });
+
+  function setup() {
+    return new CertificateManager();
+  }
+});
+
+function getTime1yearFrom(date = new Date()): number {
+  const clone = new Date(date);
+  const inOneYear = new Date(date);
+  inOneYear.setFullYear(clone.getFullYear() + 1);
+  return inOneYear.getTime();
+}

--- a/ts/src/auth/certificates/CertificateManager.ts
+++ b/ts/src/auth/certificates/CertificateManager.ts
@@ -1,0 +1,167 @@
+import type { PrivateKeyOutputFormatType } from "jsrsasign";
+import rs from "jsrsasign";
+
+/**
+ * Represents the PEM encoded certificate, public key, and private key.
+ */
+export interface CertificatePem {
+  cert: string;
+  publicKey: string;
+  privateKey: string;
+}
+
+/**
+ * Represents the information extracted from a certificate.
+ */
+export interface CertificateInfo {
+  hSerial: string;
+  sIssuer: string;
+  sSubject: string;
+  sNotBefore: string;
+  sNotAfter: string;
+  issuedOn: Date;
+  expiresOn: Date;
+}
+
+/**
+ * Options for specifying the validity range of a certificate.
+ */
+export interface ValidityRangeOptions {
+  validFrom?: Date;
+  validTo?: Date;
+}
+
+/**
+ * Manages the creation and parsing of certificates.
+ */
+export class CertificateManager {
+  /**
+   * Parses a PEM encoded certificate and extracts its information.
+   * @param certPEM - The PEM encoded certificate string.
+   * @returns An object containing the certificate information.
+   * @example
+   * const certificateManager = new CertificateManager();
+   * const pem = certificateManager.generatePEM('exampleAddress');
+   * const certInfo = certificateManager.parsePem(pem.cert);
+   * console.log(certInfo);
+   */
+  async parsePem(certPEM: string): Promise<CertificateInfo> {
+    const certificate = new rs.X509();
+    certificate.readCertPEM(certPEM);
+
+    return {
+      hSerial: certificate.getSerialNumberHex(),
+      sIssuer: certificate.getIssuerString(),
+      sSubject: certificate.getSubjectString(),
+      sNotBefore: certificate.getNotBefore(),
+      sNotAfter: certificate.getNotAfter(),
+      issuedOn: strToDate(certificate.getNotBefore()),
+      expiresOn: strToDate(certificate.getNotAfter()),
+    };
+  }
+
+  /**
+   * Generates a PEM encoded certificate, public key, and private key.
+   * @param address - The address to be used as the certificate's subject and issuer.
+   * @param options - Optional validity range for the certificate.
+   * @returns An object containing the PEM encoded certificate, public key, and private key.
+   * @example
+   * const certificateManager = new CertificateManager();
+   * const pem = certificateManager.generatePEM('exampleAddress');
+   * console.log('Certificate:', pem.cert);
+   * console.log('Public Key:', pem.publicKey);
+   * console.log('Private Key:', pem.privateKey);
+   */
+  async generatePEM(address: string, options?: ValidityRangeOptions): Promise<CertificatePem> {
+    const { notBeforeStr, notAfterStr } = this.createValidityRange(options);
+    const { prvKeyObj, pubKeyObj } = rs.KEYUTIL.generateKeypair("EC", "secp256r1");
+    const cert = new rs.KJUR.asn1.x509.Certificate({
+      version: 3,
+      serial: { int: Math.floor(Date.now() * 1000) },
+      issuer: { str: "/CN=" + address },
+      notbefore: notBeforeStr,
+      notafter: notAfterStr,
+      subject: { str: "/CN=" + address },
+      sbjpubkey: pubKeyObj,
+      ext: [
+        { extname: "keyUsage", critical: true, names: ["keyEncipherment", "dataEncipherment"] },
+        {
+          extname: "extKeyUsage",
+          array: [{ name: "clientAuth" }],
+        },
+        { extname: "basicConstraints", cA: true, critical: true },
+      ],
+      sigalg: "SHA256withECDSA",
+      cakey: prvKeyObj,
+    });
+    const publicKey = rs.KEYUTIL.getPEM(pubKeyObj, "PKCS8PUB" as PrivateKeyOutputFormatType).replaceAll("PUBLIC KEY", "EC PUBLIC KEY");
+    const certPEM = cert.getPEM();
+
+    return {
+      cert: certPEM,
+      publicKey,
+      privateKey: rs.KEYUTIL.getPEM(prvKeyObj, "PKCS8PRV"),
+    };
+  }
+
+  /**
+   * Creates a validity range for a certificate.
+   * @param options - Optional validity range options.
+   * @returns An object containing the notBefore and notAfter date strings.
+   */
+  private createValidityRange(options?: ValidityRangeOptions) {
+    const notBefore = options?.validFrom || new Date();
+    const notAfter = options?.validTo || new Date();
+
+    if (!options?.validTo) {
+      notAfter.setFullYear(notBefore.getFullYear() + 1);
+    }
+
+    const notBeforeStr = dateToStr(notBefore);
+    const notAfterStr = dateToStr(notAfter);
+
+    return { notBeforeStr, notAfterStr };
+  }
+}
+
+/**
+ * Converts a Date object to a string in the format YYMMDDHHMMSSZ.
+ * @private
+ * @param date - The date to convert.
+ * @returns The formatted date string.
+ * @example
+ * const certificateManager = new CertificateManager();
+ * const dateStr = certificateManager.dateToStr(new Date('2024-05-07T12:23:50.000Z'));
+ * console.log(dateStr); // "240507122350Z"
+ */
+export function dateToStr(date: Date): string {
+  const year = date.getUTCFullYear().toString().slice(2).padStart(2, "0");
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
+  const day = date.getUTCDate().toString().padStart(2, "0");
+  const hours = date.getUTCHours().toString().padStart(2, "0");
+  const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+  const secs = date.getUTCSeconds().toString().padStart(2, "0");
+
+  return `${year}${month}${day}${hours}${minutes}${secs}Z`;
+}
+
+/**
+ * Converts a string in the format YYMMDDHHMMSSZ to a Date object.
+ * @private
+ * @param str - The string to convert.
+ * @returns The corresponding Date object.
+ * @example
+ * const certificateManager = new CertificateManager();
+ * const date = certificateManager.strToDate("240507122350Z");
+ * console.log(date.toISOString()); // "2024-05-07T12:23:50.000Z"
+ */
+export function strToDate(str: string): Date {
+  const year = parseInt(`20${str.substring(0, 2)}`);
+  const month = parseInt(str.substring(2, 4)) - 1;
+  const day = parseInt(str.substring(4, 6));
+  const hours = parseInt(str.substring(6, 8));
+  const minutes = parseInt(str.substring(8, 10));
+  const secs = parseInt(str.substring(10, 12));
+
+  return new Date(Date.UTC(year, month, day, hours, minutes, secs));
+}

--- a/ts/src/auth/certificates/index.ts
+++ b/ts/src/auth/certificates/index.ts
@@ -1,0 +1,4 @@
+import { CertificateManager } from "./CertificateManager.ts";
+
+export const certificateManager = new CertificateManager();
+export { CertificateManager };

--- a/ts/src/sdk/nodejs/createChainNodeSDK.ts
+++ b/ts/src/sdk/nodejs/createChainNodeSDK.ts
@@ -7,6 +7,8 @@ import type { StargateClientOptions } from "../../transport/tx/txClient/createSt
 import { createStargateClient } from "../../transport/tx/txClient/createStargateClient.ts";
 import { createMessageType } from "../../utils/createServiceLoader.ts";
 
+export type { PayloadOf, ResponseOf } from "../types.ts";
+
 export function createChainNodeSDK(options: ChainNodeSDKOptions) {
   const queryTransport = createGrpcTransport({
     baseUrl: options.query.baseUrl,

--- a/ts/src/sdk/nodejs/createProviderSDK.ts
+++ b/ts/src/sdk/nodejs/createProviderSDK.ts
@@ -2,6 +2,8 @@ import { createSDK } from "../../generated/createProviderSDK.ts";
 import { createGrpcTransport } from "../../transport/grpc/createGrpcTransport.ts";
 import type { PickByPath } from "../../utils/types.ts";
 
+export type { PayloadOf, ResponseOf } from "../types.ts";
+
 type ProviderSDK = PickByPath<ReturnType<typeof createSDK>, "akash.provider.v1">;
 
 export function createProviderSDK(options: ProviderSDKOptions): ProviderSDK {

--- a/ts/src/sdk/types.ts
+++ b/ts/src/sdk/types.ts
@@ -1,4 +1,10 @@
 import type { ServiceClientOptions } from "../client/createServiceClient.ts";
+import type { SDKMethod } from "../utils/sdkMetadata.ts";
+
 export interface SDKOptions {
   clientOptions?: ServiceClientOptions;
 }
+
+export type PayloadOf<T extends SDKMethod> = Parameters<T>[0];
+
+export type ResponseOf<T extends SDKMethod> = Awaited<ReturnType<T>>;

--- a/ts/src/utils/sdkMetadata.ts
+++ b/ts/src/utils/sdkMetadata.ts
@@ -9,7 +9,7 @@ export function getMetadata(fn: SDKMethod): SDKMethodMetadata | undefined {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SDKMethod = (input: any, options?: any) => Promise<any>;
+export type SDKMethod = (input: any, options?: any) => Promise<any>;
 
 interface SDKMethodMetadata {
   /**


### PR DESCRIPTION
## Why

mTLS is used as authentication type for provider API and should be a part of our TS SDK

## What

1. Moves `CertificateManager` from akashjs and converted its methods to async functions because potentially in the future we will migrate to webcrypto 
2. Hides `proto/*` types. Instead user of the library will be able to use `PayloadOf` and `ResponseOf` methods:

```ts
import { createChainNodeSDK, PayloadOf } from "@akashnetwork/sdk/chain-node";

const sdk = createChainNodeSDK(...);

const params: PayloadOf<typeof sdk.akash.cert.v1.getCertificates> = {
  pagination: {
    limit: "1",
  },
};
const certificates = await sdk.akash.cert.v1.getCertificates(params);
```