### PR TITLE
feat: off-chain provider client

### DIFF
--- a/go/provider/client/client.go
+++ b/go/provider/client/client.go
@@ -53,6 +53,7 @@ const (
 )
 
 var ErrNotInitialized = errors.New("rest: not initialized")
+var ErrRPCClientNotSet = errors.New("rest: RPC client not set - use NewClient instead of NewClientOffChain for on-chain operations")
 
 type ReqClient interface {
 	DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error)
@@ -283,6 +284,10 @@ func (c *reqClient) DialContext(ctx context.Context, urlStr string, requestHeade
 }
 
 func (c *client) GetAccountCertificate(ctx context.Context, owner sdk.Address, serial *big.Int) (*x509.Certificate, crypto.PublicKey, error) {
+	if c.cclient == nil {
+		return nil, nil, ErrRPCClientNotSet
+	}
+
 	cresp, err := c.cclient.Certificates(ctx, &ctypes.QueryCertificatesRequest{
 		Filter: ctypes.CertificateFilter{
 			Owner:  owner.String(),

--- a/go/provider/client/client.go
+++ b/go/provider/client/client.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -19,14 +20,12 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
-	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/remotecommand"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	manifest "github.com/akash-network/akash-api/go/manifest/v2beta2"
 	ctypes "github.com/akash-network/akash-api/go/node/cert/v1beta3"
-	aclient "github.com/akash-network/akash-api/go/node/client/v1beta2"
 	dtypes "github.com/akash-network/akash-api/go/node/deployment/v1beta3"
 	mtypes "github.com/akash-network/akash-api/go/node/market/v1beta4"
 	ptypes "github.com/akash-network/akash-api/go/node/provider/v1beta3"
@@ -52,8 +51,10 @@ const (
 	PingPeriod = 10 * time.Second
 )
 
-var ErrNotInitialized = errors.New("rest: not initialized")
-var ErrRPCClientNotSet = errors.New("rest: RPC client not set - use NewClient instead of NewClientOffChain for on-chain operations")
+var (
+	ErrNotInitialized  = errors.New("rest: not initialized")
+	ErrRPCClientNotSet = errors.New("rest: RPC client not set - use WithQueryClient option for on-chain operations")
+)
 
 type ReqClient interface {
 	DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error)
@@ -105,45 +106,38 @@ type reqClient struct {
 // provider queries, the provider's address, and optional ClientOption functions for customizing
 // the client configuration.
 //
-// The following options can be provided.
+// The following options can be provided:
 //   - WithAuthCerts: Configure TLS certificates for secure communication
 //   - WithAuthJWTSigner: Set a JWT signer for authentication
 //   - WithAuthToken: Provide an authentication token
+//   - WithQueryClient: Set a query client for on-chain provider discovery (for on-chain operations)
+//   - WithProviderURL: Set a provider URL directly (for off-chain operations)
 //
-// Note, auth have the following priority: WithAuthCerts > WithAuthJWTSigner > WithAuthToken
+// Note: WithQueryClient and WithProviderURL are mutually exclusive.
+// Auth options have the following priority: WithAuthCerts > WithAuthJWTSigner > WithAuthToken
 //
 // The function will:
 // 1. Apply any provided ClientOptions
-// 2. Query the provider's host URI using the QueryClient
+// 2. Query the provider's host URI using the QueryClient (if provided) or use the direct URL
 // 3. Set up TLS configuration with system certificates
 // 4. Configure client authentication using either provided certificates or JWT signing
 //
 // Returns an error if:
 // - Any ClientOption fails to apply
-// - The provider query fails
+// - Both WithQueryClient and WithProviderURL are provided
+// - Neither WithQueryClient nor WithProviderURL are provided
+// - The provider query fails (when using QueryClient)
 // - The host URI is invalid
 // - System certificates cannot be loaded
-func NewClient(ctx context.Context, qclient aclient.QueryClient, addr sdk.Address, opts ...ClientOption) (Client, error) {
-	res, err := qclient.Provider(ctx, &ptypes.QueryProviderRequest{Owner: addr.String()})
-	if err != nil {
-		return nil, err
-	}
-
-	uri, err := url.Parse(res.Provider.HostURI)
-	if err != nil {
-		return nil, err
-	}
-
+func NewClient(ctx context.Context, addr sdk.Address, opts ...ClientOption) (Client, error) {
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, err
 	}
 
 	cl := &client{
-		ctx:     ctx,
-		host:    uri,
-		addr:    addr,
-		cclient: qclient,
+		ctx:  ctx,
+		addr: addr,
 	}
 
 	for _, opt := range opts {
@@ -153,54 +147,41 @@ func NewClient(ctx context.Context, qclient aclient.QueryClient, addr sdk.Addres
 		}
 	}
 
-	cl.tlsCfg = &tls.Config{
-		InsecureSkipVerify:    true, // nolint: gosec
-		VerifyPeerCertificate: cl.verifyPeerCertificate,
-		MinVersion:            tls.VersionTLS13,
-		RootCAs:               certPool,
+	if cl.opts.qclient == nil && cl.opts.providerURL == "" {
+		return nil, errors.New("either WithQueryClient or WithProviderURL must be provided")
 	}
 
-	if len(cl.opts.certs) > 0 {
-		cl.tlsCfg.Certificates = cl.opts.certs
-	} else if cl.opts.signer != nil || cl.opts.token != "" {
-		// must use Hostname rather than Host field as a certificate is issued for host without port
-		cl.tlsCfg.ServerName = uri.Host
-	}
+	var uri *url.URL
+	if cl.opts.qclient != nil {
+		// On-chain mode: query provider information
+		cl.cclient = cl.opts.qclient
+		res, err := cl.opts.qclient.Provider(ctx, &ptypes.QueryProviderRequest{Owner: addr.String()})
+		if err != nil {
+			return nil, err
+		}
 
-	return cl, nil
-}
-
-// NewClientOffChain creates a new client that does not make any on-chain requests and skips peer certificate verification.
-// Note: This is a limited client and should only be used in controlled schenarios.
-func NewClientOffChain(ctx context.Context, providerURL string, addr sdk.Address, opts ...ClientOption) (Client, error) {
-	uri, err := url.Parse(providerURL)
-	if err != nil {
-		return nil, err
-	}
-
-	certPool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, err
-	}
-
-	cl := &client{
-		ctx:     ctx,
-		host:    uri,
-		addr:    addr,
-		cclient: nil,
-	}
-
-	for _, opt := range opts {
-		err := opt(&cl.opts)
+		uri, err = url.Parse(res.Provider.HostURI)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Off-chain mode: use provided URL directly
+		uri, err = url.Parse(cl.opts.providerURL)
 		if err != nil {
 			return nil, err
 		}
 	}
+
+	cl.host = uri
 
 	cl.tlsCfg = &tls.Config{
 		InsecureSkipVerify: true, // nolint: gosec
 		MinVersion:         tls.VersionTLS13,
 		RootCAs:            certPool,
+	}
+
+	if cl.cclient != nil {
+		cl.tlsCfg.VerifyPeerCertificate = cl.verifyPeerCertificate
 	}
 
 	if len(cl.opts.certs) > 0 {
@@ -678,7 +659,7 @@ func (c *client) LeaseEvents(ctx context.Context, id mtypes.LeaseID, _ string, f
 	case schemeWSS, schemeHTTPS:
 		endpoint.Scheme = schemeWSS
 	default:
-		return nil, errors.Errorf("invalid uri scheme %q", endpoint.Scheme)
+		return nil, fmt.Errorf("invalid uri scheme %q", endpoint.Scheme)
 	}
 
 	query := url.Values{}
@@ -858,7 +839,7 @@ func (c *client) LeaseLogs(ctx context.Context,
 	case schemeWSS, schemeHTTPS:
 		endpoint.Scheme = schemeWSS
 	default:
-		return nil, errors.Errorf("invalid uri scheme \"%s\"", endpoint.Scheme)
+		return nil, fmt.Errorf("invalid uri scheme \"%s\"", endpoint.Scheme)
 	}
 
 	query := url.Values{}

--- a/go/provider/client/client.go
+++ b/go/provider/client/client.go
@@ -169,7 +169,9 @@ func NewClient(ctx context.Context, qclient aclient.QueryClient, addr sdk.Addres
 	return cl, nil
 }
 
-func NewClientV2(ctx context.Context, qclient aclient.QueryClient, providerURL string, addr sdk.Address, opts ...ClientOption) (Client, error) {
+// NewClientOffChain creates a new client that does not make any on-chain requests and skips peer certificate verification.
+// Note: This is a limited client and should only be used in controlled schenarios.
+func NewClientOffChain(ctx context.Context, providerURL string, addr sdk.Address, opts ...ClientOption) (Client, error) {
 	uri, err := url.Parse(providerURL)
 	if err != nil {
 		return nil, err
@@ -184,7 +186,7 @@ func NewClientV2(ctx context.Context, qclient aclient.QueryClient, providerURL s
 		ctx:     ctx,
 		host:    uri,
 		addr:    addr,
-		cclient: qclient,
+		cclient: nil,
 	}
 
 	for _, opt := range opts {

--- a/go/provider/client/client_test.go
+++ b/go/provider/client/client_test.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"errors"
+	"math/big"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -62,6 +63,18 @@ func TestNewClientOffChain(t *testing.T) {
 		_, err := NewClientOffChain(ctx, providerURL, addr, errorOption)
 		require.Error(t, err)
 		require.Equal(t, testError, err)
+	})
+
+	t.Run("RPC client not set error", func(t *testing.T) {
+		cl, err := NewClientOffChain(ctx, providerURL, addr)
+		require.NoError(t, err)
+
+		c := cl.(*client)
+		require.Nil(t, c.cclient)
+
+		_, _, err = c.GetAccountCertificate(ctx, addr, big.NewInt(1))
+		require.Error(t, err)
+		require.Equal(t, ErrRPCClientNotSet, err)
 	})
 
 }

--- a/go/provider/client/client_test.go
+++ b/go/provider/client/client_test.go
@@ -1,0 +1,67 @@
+package rest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientOffChain(t *testing.T) {
+	ctx := context.Background()
+	providerURL := "https://example.com:8443"
+	addr, err := sdk.AccAddressFromBech32("akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63")
+	require.NoError(t, err)
+
+	t.Run("basic functionality", func(t *testing.T) {
+		cl, err := NewClientOffChain(ctx, providerURL, addr)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
+
+		c := cl.(*client)
+		require.Nil(t, c.cclient)
+		require.Equal(t, ctx, c.ctx)
+		require.Equal(t, addr, c.addr)
+		require.NotNil(t, c.host)
+		require.NotNil(t, c.tlsCfg)
+	})
+
+	t.Run("options are executed", func(t *testing.T) {
+		optionCalled := false
+		token := "test-token"
+
+		testOption := func(opts *clientOptions) error {
+			optionCalled = true
+			opts.token = token
+			return nil
+		}
+
+		cl, err := NewClientOffChain(ctx, providerURL, addr, testOption)
+		require.NoError(t, err)
+		require.True(t, optionCalled, "ClientOption should have been called")
+
+		c := cl.(*client)
+		require.Nil(t, c.cclient)
+		require.Equal(t, token, c.opts.token)
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		invalidURL := "://invalid-url"
+		_, err := NewClientOffChain(ctx, invalidURL, addr)
+		require.Error(t, err)
+	})
+
+	t.Run("option error handling", func(t *testing.T) {
+		testError := errors.New("test error")
+		errorOption := func(opts *clientOptions) error {
+			return testError
+		}
+
+		_, err := NewClientOffChain(ctx, providerURL, addr, errorOption)
+		require.Error(t, err)
+		require.Equal(t, testError, err)
+	})
+
+}

--- a/go/provider/client/options.go
+++ b/go/provider/client/options.go
@@ -7,9 +7,10 @@ import (
 )
 
 type clientOptions struct {
-	certs  []tls.Certificate
-	signer ajwt.SignerI
-	token  string
+	certs       []tls.Certificate
+	signer      ajwt.SignerI
+	token       string
+	providerURL string
 }
 
 // ClientOption is a function type that modifies a clientOptions struct and returns an error.
@@ -45,6 +46,13 @@ func WithAuthJWTSigner(val ajwt.SignerI) ClientOption {
 func WithAuthToken(val string) ClientOption {
 	return func(options *clientOptions) error {
 		options.token = val
+		return nil
+	}
+}
+
+func WithProviderURL(val string) ClientOption {
+	return func(options *clientOptions) error {
+		options.providerURL = val
 		return nil
 	}
 }

--- a/go/provider/client/options.go
+++ b/go/provider/client/options.go
@@ -2,14 +2,18 @@ package rest
 
 import (
 	"crypto/tls"
+	"errors"
 
+	aclient "github.com/akash-network/akash-api/go/node/client/v1beta2"
 	ajwt "github.com/akash-network/akash-api/go/util/jwt"
 )
 
 type clientOptions struct {
-	certs  []tls.Certificate
-	signer ajwt.SignerI
-	token  string
+	certs       []tls.Certificate
+	signer      ajwt.SignerI
+	token       string
+	providerURL string
+	qclient     aclient.QueryClient
 }
 
 // ClientOption is a function type that modifies a clientOptions struct and returns an error.
@@ -45,6 +49,37 @@ func WithAuthJWTSigner(val ajwt.SignerI) ClientOption {
 func WithAuthToken(val string) ClientOption {
 	return func(options *clientOptions) error {
 		options.token = val
+		return nil
+	}
+}
+
+var ErrMutuallyExclusiveOptions = errors.New("WithProviderURL and WithQueryClient are mutually exclusive")
+
+// WithProviderURL configures the client to use the specified provider URL directly.
+// This option is mutually exclusive with WithQueryClient.
+func WithProviderURL(providerURL string) ClientOption {
+	return func(options *clientOptions) error {
+		if options.qclient != nil {
+			return ErrMutuallyExclusiveOptions
+		}
+		options.providerURL = providerURL
+		return nil
+	}
+}
+
+// WithQueryClient configures the client to use the specified query client for provider discovery.
+// This option is mutually exclusive with WithProviderURL.
+func WithQueryClient(qclient aclient.QueryClient) ClientOption {
+	return func(options *clientOptions) error {
+		if options.providerURL != "" {
+			return ErrMutuallyExclusiveOptions
+		}
+
+		if qclient == nil {
+			return errors.New("query client is nil")
+		}
+
+		options.qclient = qclient
 		return nil
 	}
 }

--- a/go/provider/client/options.go
+++ b/go/provider/client/options.go
@@ -7,10 +7,9 @@ import (
 )
 
 type clientOptions struct {
-	certs       []tls.Certificate
-	signer      ajwt.SignerI
-	token       string
-	providerURL string
+	certs  []tls.Certificate
+	signer ajwt.SignerI
+	token  string
 }
 
 // ClientOption is a function type that modifies a clientOptions struct and returns an error.
@@ -46,13 +45,6 @@ func WithAuthJWTSigner(val ajwt.SignerI) ClientOption {
 func WithAuthToken(val string) ClientOption {
 	return func(options *clientOptions) error {
 		options.token = val
-		return nil
-	}
-}
-
-func WithProviderURL(val string) ClientOption {
-	return func(options *clientOptions) error {
-		options.providerURL = val
 		return nil
 	}
 }


### PR DESCRIPTION
## 🌟 PR Title
Introduce an off-chain provider client that doesn't rely on an available RPC node.

## 📝 Description

## 🔧 Purpose of the Change
- [X] New feature implementation
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency upgrade
- [ ] Other: [specify]

## 📌 Related Issues
- References [#297](https://github.com/akash-network/support/issues/297)
## ✅ Checklist
- [X] I've updated relevant documentation
- [X] Code follows Akash Network's style guide
- [X] I've added/updated relevant unit tests
- [X] Dependencies have been properly updated
- [X] I agree and adhered to the [Contribution Guidelines](https://github.com/akash-network/akash-api/blob/main/CONTRIBUTING.md)

## 📎 Notes for Reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an off-chain provider mode (supply a provider URL) alongside on-chain discovery; TLS/host resolution adjusted for each mode.

- Public API Changes
  - New explicit error when on-chain RPC client is not configured.
  - Networking client now supports direct HTTP request usage.
  - Provider configuration options are mutually exclusive and surface a clear error when combined.

- Tests
  - Added tests covering off-chain creation, option validation, invalid URL handling, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->